### PR TITLE
fix: avoid reporting processing error for malformed messages

### DIFF
--- a/chain/indexer.go
+++ b/chain/indexer.go
@@ -160,7 +160,6 @@ func (t *TipSetIndexer) TipSet(ctx context.Context, ts *types.TipSet) error {
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Name, t.name))
-	log.Debugw("indexing tipset", "height", ts.Height())
 
 	var cancel func()
 	var tctx context.Context // cancellable context for the task
@@ -208,6 +207,7 @@ func (t *TipSetIndexer) TipSet(ctx context.Context, ts *types.TipSet) error {
 	}
 
 	ll := log.With("current", int64(current.Height()), "next", int64(next.Height()))
+	ll.Debugw("indexing tipset")
 
 	// Run each tipset processing task concurrently
 	for name, p := range t.processors {

--- a/lens/lily/impl.go
+++ b/lens/lily/impl.go
@@ -196,7 +196,7 @@ func (m *LilyNodeAPI) GetMessageExecutionsForTipSet(ctx context.Context, next *t
 		}
 	}
 
-	getActorCode, err := util.MakeGetActorCodeFunc(ctx, m.ChainAPI.Chain.ActorStore(ctx), current)
+	getActorCode, err := util.MakeGetActorCodeFunc(ctx, m.ChainAPI.Chain.ActorStore(ctx), next, current)
 	if err != nil {
 		return nil, xerrors.Errorf("failed to make actor code query function: %w", err)
 	}

--- a/lens/util/repo.go
+++ b/lens/util/repo.go
@@ -508,6 +508,7 @@ func MakeGetActorCodeFunc(ctx context.Context, store adt.Store, ts, pts *types.T
 	return func(a address.Address) (cid.Cid, bool) {
 		ra, found, err := initActorState.ResolveAddress(a)
 		if err != nil || !found {
+			log.Warnw("failed to resolve actor address", "address", a.String())
 			return cid.Undef, false
 		}
 

--- a/lens/util/repo.go
+++ b/lens/util/repo.go
@@ -481,7 +481,7 @@ func MakeGetActorCodeFunc(ctx context.Context, store adt.Store, ts, pts *types.T
 		return nil, xerrors.Errorf("child tipset (%s) is not on the same chain as parent (%s)", ts.Key(), pts.Key())
 	}
 
-	stateTree, err := state.LoadStateTree(store, ts.ParentState())
+	stateTree, err := state.LoadStateTree(store, pts.ParentState())
 	if err != nil {
 		return nil, xerrors.Errorf("load state tree: %w", err)
 	}
@@ -523,6 +523,7 @@ func MakeGetActorCodeFunc(ctx context.Context, store adt.Store, ts, pts *types.T
 			return c, true
 		}
 
+		log.Warnw("failed to find actor code", "address", a.String(), "resolved", ra.String())
 		return cid.Undef, false
 	}, nil
 }

--- a/lens/util/repo.go
+++ b/lens/util/repo.go
@@ -528,6 +528,13 @@ func MakeGetActorCodeFunc(ctx context.Context, store adt.Store, next, current *t
 	}
 
 	return func(a address.Address) (cid.Cid, bool) {
+		act, err := nextStateTree.GetActor(a)
+		if err != nil {
+			log.Warnw("failed to get actor", "error", err.Error(), "address", a.String())
+		}
+		if act != nil {
+			log.Debugw("got actor", "address", a.String(), "code", act.Code)
+		}
 		c, ok := actorCodes[a]
 		if ok {
 			return c, true

--- a/lens/util/repo.go
+++ b/lens/util/repo.go
@@ -506,13 +506,19 @@ func MakeGetActorCodeFunc(ctx context.Context, store adt.Store, ts, pts *types.T
 	}
 
 	return func(a address.Address) (cid.Cid, bool) {
+		c, ok := actorCodes[a]
+		if ok {
+			log.Debugw("found actor code with unresolved address", "address", a.String(), "code", c.String())
+			return c, true
+		}
+
 		ra, found, err := initActorState.ResolveAddress(a)
 		if err != nil || !found {
 			log.Warnw("failed to resolve actor address", "address", a.String())
 			return cid.Undef, false
 		}
 
-		c, ok := actorCodes[ra]
+		c, ok = actorCodes[ra]
 		if ok {
 			return c, true
 		}

--- a/tasks/messages/message.go
+++ b/tasks/messages/message.go
@@ -233,7 +233,7 @@ func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types
 			}
 			parsedMessageResults = append(parsedMessageResults, pm)
 		} else {
-			if rcpt.ExitCode == int64(exitcode.ErrSerialization) {
+			if rcpt.ExitCode == int64(exitcode.ErrSerialization) || rcpt.ExitCode == int64(exitcode.ErrIllegalArgument) {
 				// ignore the parse error since the params are probably malformed, as reported by the vm
 			} else {
 				errorsDetected = append(errorsDetected, &MessageError{

--- a/tasks/messages/message.go
+++ b/tasks/messages/message.go
@@ -94,6 +94,21 @@ func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types
 				})
 			}
 
+			// To and From may be empty if the actor could not be found in the state tree
+			if msg.Message.To.Empty() {
+				errorsDetected = append(errorsDetected, &MessageError{
+					Cid:   msg.Cid(),
+					Error: "to address is empty",
+				})
+			}
+
+			if msg.Message.From.Empty() {
+				errorsDetected = append(errorsDetected, &MessageError{
+					Cid:   msg.Cid(),
+					Error: "from address is empty",
+				})
+			}
+
 			// record all unique Secp messages
 			msg := &messagemodel.Message{
 				Height:     int64(bm.Block.Height),
@@ -130,6 +145,21 @@ func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types
 				errorsDetected = append(errorsDetected, &MessageError{
 					Cid:   msg.Cid(),
 					Error: xerrors.Errorf("failed to serialize message: %w", err).Error(),
+				})
+			}
+
+			// To and From may be empty if the actor could not be found in the state tree
+			if msg.To.Empty() {
+				errorsDetected = append(errorsDetected, &MessageError{
+					Cid:   msg.Cid(),
+					Error: "to address is empty",
+				})
+			}
+
+			if msg.From.Empty() {
+				errorsDetected = append(errorsDetected, &MessageError{
+					Cid:   msg.Cid(),
+					Error: "from address is empty",
 				})
 			}
 
@@ -276,6 +306,10 @@ func (p *Task) parseMessageParams(m *types.Message, destCode cid.Cid) (string, s
 	// Method is optional, zero means a plain value transfer
 	if m.Method == 0 {
 		return "Send", "", nil
+	}
+
+	if !destCode.Defined() {
+		return "Unknown", "", nil
 	}
 
 	var params ipld.Node

--- a/tasks/messages/message.go
+++ b/tasks/messages/message.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"math/big"
 
+	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -232,10 +233,14 @@ func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types
 			}
 			parsedMessageResults = append(parsedMessageResults, pm)
 		} else {
-			errorsDetected = append(errorsDetected, &MessageError{
-				Cid:   m.Cid,
-				Error: xerrors.Errorf("failed to parse message params: %w", err).Error(),
-			})
+			if rcpt.ExitCode == int64(exitcode.ErrSerialization) {
+				// ignore the parse error since the params are probably malformed, as reported by the vm
+			} else {
+				errorsDetected = append(errorsDetected, &MessageError{
+					Cid:   m.Cid,
+					Error: xerrors.Errorf("failed to parse message params: %w", err).Error(),
+				})
+			}
 		}
 	}
 

--- a/tasks/messages/message.go
+++ b/tasks/messages/message.go
@@ -94,21 +94,6 @@ func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types
 				})
 			}
 
-			// To and From may be empty if the actor could not be found in the state tree
-			if msg.Message.To.Empty() {
-				errorsDetected = append(errorsDetected, &MessageError{
-					Cid:   msg.Cid(),
-					Error: "to address is empty",
-				})
-			}
-
-			if msg.Message.From.Empty() {
-				errorsDetected = append(errorsDetected, &MessageError{
-					Cid:   msg.Cid(),
-					Error: "from address is empty",
-				})
-			}
-
 			// record all unique Secp messages
 			msg := &messagemodel.Message{
 				Height:     int64(bm.Block.Height),
@@ -145,21 +130,6 @@ func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types
 				errorsDetected = append(errorsDetected, &MessageError{
 					Cid:   msg.Cid(),
 					Error: xerrors.Errorf("failed to serialize message: %w", err).Error(),
-				})
-			}
-
-			// To and From may be empty if the actor could not be found in the state tree
-			if msg.To.Empty() {
-				errorsDetected = append(errorsDetected, &MessageError{
-					Cid:   msg.Cid(),
-					Error: "to address is empty",
-				})
-			}
-
-			if msg.From.Empty() {
-				errorsDetected = append(errorsDetected, &MessageError{
-					Cid:   msg.Cid(),
-					Error: "from address is empty",
 				})
 			}
 
@@ -309,7 +279,7 @@ func (p *Task) parseMessageParams(m *types.Message, destCode cid.Cid) (string, s
 	}
 
 	if !destCode.Defined() {
-		return "Unknown", "", nil
+		return "Unknown", "", xerrors.Errorf("missing actor code")
 	}
 
 	var params ipld.Node

--- a/tasks/messages/message_test.go
+++ b/tasks/messages/message_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/lotus/chain/types"
+	builtin4 "github.com/filecoin-project/specs-actors/v4/actors/builtin"
 	builtin5 "github.com/filecoin-project/specs-actors/v5/actors/builtin"
 	"github.com/ipfs/go-cid"
 )
@@ -79,6 +80,16 @@ func TestParseMessageParams(t *testing.T) {
 			wantMethod:  "InitExecParams",
 			wantEncoded: "",
 			wantErr:     true,
+		},
+		{
+			// Derived from message bafy2bzacedqt52o7iyghmiqvvgjvcc2bw3xivspj635tl7dtlrsasreaby5ug
+			name:        "issue-668",
+			method:      24,
+			params:      mustDecodeBase64(t, "ghIB"),
+			actorCode:   builtin4.StorageMinerActorCodeID,
+			wantMethod:  "DisputeWindowedPoSt",
+			wantEncoded: "{\n\t\"Deadline\": 18,\n\t\"PoStIndex\": 1\n}\n",
+			wantErr:     false,
 		},
 	}
 

--- a/tasks/messages/message_test.go
+++ b/tasks/messages/message_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/lotus/chain/types"
-	// builtin5 "github.com/filecoin-project/specs-actors/v5/actors/builtin"
 	"github.com/ipfs/go-cid"
 )
 

--- a/tasks/messages/message_test.go
+++ b/tasks/messages/message_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/lotus/chain/types"
-	builtin3 "github.com/filecoin-project/specs-actors/v4/actors/builtin"
+	builtin3 "github.com/filecoin-project/specs-actors/v3/actors/builtin"
 	builtin4 "github.com/filecoin-project/specs-actors/v4/actors/builtin"
 	builtin5 "github.com/filecoin-project/specs-actors/v5/actors/builtin"
 	"github.com/ipfs/go-cid"

--- a/tasks/messages/message_test.go
+++ b/tasks/messages/message_test.go
@@ -1,13 +1,24 @@
 package messages
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/lotus/chain/types"
+	builtin5 "github.com/filecoin-project/specs-actors/v5/actors/builtin"
 	"github.com/ipfs/go-cid"
 )
+
+func mustDecodeBase64(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		t.Fatalf("bad base64 data: %v", err)
+	}
+	return b
+}
 
 func TestParseMessageParams(t *testing.T) {
 	testCases := []struct {
@@ -26,6 +37,46 @@ func TestParseMessageParams(t *testing.T) {
 			params:      nil,
 			actorCode:   cid.Undef,
 			wantMethod:  "Unknown",
+			wantEncoded: "",
+			wantErr:     true,
+		},
+		{
+			// Derived from message bafy2bzaceah56ky4mny2qv3eg4zzjr7xxlht2bvxvcz6oozpe7k5ytjjhpezc
+			name:        "issue-664",
+			method:      2,
+			params:      mustDecodeBase64(t, "gm5maWwvMi9tdWx0aXNpZ1hFhVUBVZOiUErA4tz2x5Zz9iV/aBZBdHxVARJCEmhAYnLXQYa/1IScyah3BRgEVQE3/ahkH/xoK6Xpa0ZbDxkY/oPxiAIA"),
+			actorCode:   builtin5.InitActorCodeID,
+			wantMethod:  "InitExecParams",
+			wantEncoded: "",
+			wantErr:     true,
+		},
+		{
+			// Derived from message bafy2bzacebgq3cph66gsik2ii7sxweepqpcthvihh2oc2mzuglim2arwu4v4e
+			name:        "issue-665",
+			method:      2,
+			params:      mustDecodeBase64(t, "glgkAXEAIKIYsG+CNkex11XGSGd1TapZ7E3Pnv/QS+HCi5f8FgI/WERYPwFVk6JQSsDi3PbHlnP2JX9oFkF0fAESQhJoQGJy10GGv9SEnMmodwUYBAE3/ahkH/xoK6Xpa0ZbDxkY/oPxiAAAAA=="),
+			actorCode:   builtin5.InitActorCodeID,
+			wantMethod:  "InitExecParams",
+			wantEncoded: "",
+			wantErr:     true,
+		},
+		{
+			// Derived from message bafy2bzacedbvv6o3xbydanuzokerd5gwj7lv5anqb5wfxp7oqoctdf6xmssua
+			name:        "issue-666",
+			method:      2,
+			params:      mustDecodeBase64(t, "WCcBcaDkAiAzgZ+v0x2W+uoEsJxtRrsaX365EEcIgSCz/gbOPO8fIoQ="),
+			actorCode:   builtin5.InitActorCodeID,
+			wantMethod:  "InitExecParams",
+			wantEncoded: "",
+			wantErr:     true,
+		},
+		{
+			// Derived from message bafy2bzaceaubtkxigzl2pbhxc2rpvdprcfgg3b66gk7g5wzttxtmjfuy7lpq6
+			name:        "issue-667",
+			method:      2,
+			params:      mustDecodeBase64(t, "gtgqomZzaWduZXL1ZG5hbWVOZmlsLzUvbXVsdGlzaWdYW4SCeClmMXVldnZsdzdqeG9nc2NmZW42Y2N1dGFtbGRjdmMzZ2hwaG9zM3FkYXgpZjFheTJueXo2bm16dXlzeG9tdWp5NWc3bmF5YjQ1M2doZ2hycW55Y3kCAAA="),
+			actorCode:   builtin5.InitActorCodeID,
+			wantMethod:  "InitExecParams",
 			wantEncoded: "",
 			wantErr:     true,
 		},

--- a/tasks/messages/message_test.go
+++ b/tasks/messages/message_test.go
@@ -1,0 +1,68 @@
+package messages
+
+import (
+	"testing"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/lotus/chain/types"
+	// builtin5 "github.com/filecoin-project/specs-actors/v5/actors/builtin"
+	"github.com/ipfs/go-cid"
+)
+
+func TestParseMessageParams(t *testing.T) {
+	testCases := []struct {
+		name        string
+		method      abi.MethodNum
+		params      []byte
+		actor       cid.Cid
+		wantMethod  string
+		wantEncoded string
+		wantErr     bool
+	}{
+
+		{
+			name:        "unknown actor code",
+			method:      4,
+			params:      nil,
+			actor:       cid.Undef,
+			wantMethod:  "Unknown",
+			wantEncoded: "",
+			wantErr:     false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			task := NewTask()
+
+			to, _ := address.NewIDAddress(1)
+			from, _ := address.NewIDAddress(2)
+
+			msg := &types.Message{
+				To:   to,
+				From: from,
+
+				Method: tc.method,
+				Params: tc.params,
+			}
+
+			method, encoded, err := task.parseMessageParams(msg, tc.actor)
+			switch {
+			case tc.wantErr && err == nil:
+				t.Errorf("got no error but wanted one")
+				return
+			case !tc.wantErr && err != nil:
+				t.Errorf("got unexpected error: %v", err)
+				return
+			}
+
+			if method != tc.wantMethod {
+				t.Errorf("got method %q, wanted %q", method, tc.wantMethod)
+			}
+			if encoded != tc.wantEncoded {
+				t.Errorf("got encoded %q, wanted %q", encoded, tc.wantEncoded)
+			}
+		})
+	}
+}

--- a/tasks/messages/message_test.go
+++ b/tasks/messages/message_test.go
@@ -15,7 +15,7 @@ func TestParseMessageParams(t *testing.T) {
 		name        string
 		method      abi.MethodNum
 		params      []byte
-		actor       cid.Cid
+		actorCode   cid.Cid
 		wantMethod  string
 		wantEncoded string
 		wantErr     bool
@@ -25,7 +25,7 @@ func TestParseMessageParams(t *testing.T) {
 			name:        "unknown actor code",
 			method:      4,
 			params:      nil,
-			actor:       cid.Undef,
+			actorCode:   cid.Undef,
 			wantMethod:  "Unknown",
 			wantEncoded: "",
 			wantErr:     false,
@@ -47,7 +47,7 @@ func TestParseMessageParams(t *testing.T) {
 				Params: tc.params,
 			}
 
-			method, encoded, err := task.parseMessageParams(msg, tc.actor)
+			method, encoded, err := task.parseMessageParams(msg, tc.actorCode)
 			switch {
 			case tc.wantErr && err == nil:
 				t.Errorf("got no error but wanted one")

--- a/tasks/messages/message_test.go
+++ b/tasks/messages/message_test.go
@@ -28,7 +28,7 @@ func TestParseMessageParams(t *testing.T) {
 			actorCode:   cid.Undef,
 			wantMethod:  "Unknown",
 			wantEncoded: "",
-			wantErr:     false,
+			wantErr:     true,
 		},
 	}
 

--- a/tasks/messages/message_test.go
+++ b/tasks/messages/message_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/lotus/chain/types"
+	builtin3 "github.com/filecoin-project/specs-actors/v4/actors/builtin"
 	builtin4 "github.com/filecoin-project/specs-actors/v4/actors/builtin"
 	builtin5 "github.com/filecoin-project/specs-actors/v5/actors/builtin"
 	"github.com/ipfs/go-cid"
@@ -90,6 +91,17 @@ func TestParseMessageParams(t *testing.T) {
 			wantMethod:  "DisputeWindowedPoSt",
 			wantEncoded: "{\n\t\"Deadline\": 18,\n\t\"PoStIndex\": 1\n}\n",
 			wantErr:     false,
+		},
+		{
+			// Derived from message bafy2bzacebpiuu7tgya6yz56sfllpqc3rqbo5s5xl7353xeuavc53qlpb4sqw
+			// Account actor is not supported for parameter parsing
+			name:        "issue-663",
+			method:      1,
+			params:      nil,
+			actorCode:   builtin3.AccountActorCodeID,
+			wantMethod:  "",
+			wantEncoded: "",
+			wantErr:     true,
 		},
 	}
 

--- a/tasks/messages/messageparams.go
+++ b/tasks/messages/messageparams.go
@@ -250,7 +250,7 @@ func ParseParams(params []byte, method int64, destType cid.Cid) (ipld.Node, stri
 
 	builder := proto.NewBuilder()
 	if err := dagcbor.Decoder(builder, bytes.NewBuffer(params)); err != nil {
-		return nil, "", fmt.Errorf("cbor decode into %s (%s.%d) failed: %v", name, destType, method, err)
+		return nil, name, fmt.Errorf("cbor decode into %s (%s.%d) failed: %v", name, destType, method, err)
 	}
 
 	return builder.Build(), name, nil


### PR DESCRIPTION
We were reporting all message param parsing failures as errors in the processing report. However some messages simply have invalid parameters and failed to execute in the VM. Check this by looking at the exit code of the message and ignore the failure if the vm also failed to decode the parameters.

Note: the added test doesn't cover the ignore behaviour but documents the kind of failures we have seen in the wild.

Fixes #667, #666, #665, #664, #668, #663

~Also improves the error message reported by #660 but does not fix the underlying problem.~ Updated to also fix #660 by looking for actor in current state tree if not found in next.

PR is a little noisy because I renamed ts/pts arguments to next/current for clarity.
