### PR TITLE
fix: config file is written with working defaults

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -82,7 +82,7 @@ func SampleConf() *Conf {
 		Postgresql: map[string]PgStorageConf{
 			"Database1": {
 				URLEnv:          "LOTUS_DB", // LOTUS_DB is a historical accident, but we keep it as the default for compatibility
-				URL:             "postgres://postgres:password@localhost:5432/postgres",
+				URL:             "postgres://postgres:password@localhost:5432/postgres?sslmode=disable",
 				PoolSize:        20,
 				ApplicationName: "visor",
 				AllowUpsert:     false,
@@ -111,15 +111,15 @@ func SampleConf() *Conf {
 	return &cfg
 }
 
-func EnsureExists(path string) error {
+func EnsureExists(path string, init bool) error {
 	_, err := os.Stat(path)
-	if err == nil {
+	if err == nil && !init {
 		return nil
-	} else if !os.IsNotExist(err) {
+	} else if err != nil {
 		return err
 	}
 
-	c, err := os.Create(path)
+	c, err := os.OpenFile(path, os.O_TRUNC|os.O_WRONLY, os.ModeAppend)
 	if err != nil {
 		return err
 	}

--- a/storage/catalog.go
+++ b/storage/catalog.go
@@ -29,10 +29,11 @@ func NewCatalog(cfg config.StorageConf) (*Catalog, error) {
 
 		// Find the url of the database, which is either indirectly specified using URLEnv or explicit via URL
 		var dburl string
+		dburl = sc.URL
 		if sc.URLEnv != "" {
-			dburl = os.Getenv(sc.URLEnv)
-		} else {
-			dburl = sc.URL
+			if os.Getenv(sc.URLEnv) != "" {
+				dburl = os.Getenv(sc.URLEnv)
+			}
 		}
 
 		db, err := NewDatabase(context.TODO(), dburl, sc.PoolSize, sc.ApplicationName, sc.SchemaName, sc.AllowUpsert)


### PR DESCRIPTION
### What changes?
`visor init` will write the config file with `[Storage]` values by default. Previously this never worked.
The default config file will work once uncommented. Previously this didn't work.
`visor daemon` (with or without the config flag) will not write the `[Storage]` values.
`visor daemon --default-config=true` (defaults false) will overwrite the config file with `[Storage]` values included.