### PR TITLE
Fix partial migration check

### DIFF
--- a/storage/migrate.go
+++ b/storage/migrate.go
@@ -219,7 +219,7 @@ func (d *Database) MigrateSchemaTo(ctx context.Context, target model.Version) er
 	}
 
 	// Check if we need to create the base schema
-	if dbVersion.Patch == 0 {
+	if !initialized {
 		log.Infof("creating base schema for major version %d", target.Major)
 
 		base, err := baseForVersion(target, d.SchemaConfig())


### PR DESCRIPTION
When running migrations over a partially completed schema, the base schema creation is being attempted again due to an incorrect check.

~I've also moved a defer closer to the lock it grabs to avoid held locks if base creation fails. This is probably never a concern as the schema wouldn't be shared without the base, but it would be annoying for the lock to be held from a prior failure and then deadlock waiting to apply patches. LMK if I'm misreading this.~ Removed.

fixes #706 