### PR TITLE
chore(docker): Add lily stub/options for docker-compose

### DIFF
--- a/build/lily/docker.env
+++ b/build/lily/docker.env
@@ -1,0 +1,20 @@
+# Path for lily state should be on a persisted volume
+LILY_REPO=/var/lib/lily
+
+# Config path default is below but may be customized
+#LILY_CONFIG=/var/lib/lily/config.toml
+
+# Postgres URL may be overridden
+#LILY_STORAGE_POSTGRESQL_DB_URL=postgres://user:pass@host:port/database?options
+
+# Enable IMPORT_SNAPSHOT below to use snapshot on lily startup
+#_LILY_DOCKER_INIT_IMPORT_MAINNET_SNAPSHOT=true
+
+# Debugging options
+LILY_TRACING=true
+LILY_PROMETHEUS_PORT="prometheus:9090"
+
+# Logging options
+GOLOG_LOG_FMT=json
+GOLOG_LOG_LEVEL=info
+LILY_LOG_LEVEL_NAMED="vm:error,badgerbs:error"

--- a/build/lily/docker.env
+++ b/build/lily/docker.env
@@ -11,7 +11,7 @@ LILY_REPO=/var/lib/lily
 #_LILY_DOCKER_INIT_IMPORT_MAINNET_SNAPSHOT=true
 
 # Debugging options
-LILY_TRACING=true
+#LILY_TRACING=true
 LILY_PROMETHEUS_PORT="prometheus:9090"
 
 # Logging options

--- a/build/lily/docker_init.sh
+++ b/build/lily/docker_init.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -exo pipefail
+
+mkdir -p ${LILY_REPO}/keystore
+
+if [[ ! -z "${_LILY_DOCKER_INIT_IMPORT_MAINNET_SNAPSHOT}" ]]; then
+  # import snapshot when _LILY_DOCKER_INIT_IMPORT_MAINNET_SNAPSHOT is set
+  if [[ -f "${LILY_REPO}/datastore/_imported" ]]; then
+    echo "Skipping import, found ${LILY_REPO}/datastore/_imported file."
+  else
+    echo "Importing snapshot from https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car..."
+    lily init --import-snapshot="https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car"
+
+    status=$?
+    if [ $status -eq 0 ]; then
+      touch "/var/lib/lily/datastore/_imported"
+    fi
+  fi
+else
+  # otherwise only init
+  lily init
+fi
+
+chmod 0600 ${LILY_REPO}/keystore/*
+
+lily $@

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,3 +80,4 @@ volumes:
   timescaledb: {}
   prometheus_data: {}
   grafana_data: {}
+  lily_data: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,28 @@ services:
       - ./build/grafana/config.monitoring
     restart: always
 
+  #lily:
+    #container_name: lily
+    ## Select (only one) image
+    #image: filecoin/lily:v0.8.0
+    #image: filecoin/lily:v0.8.0-calibnet
+    #image: filecoin/lily:v0.8.0-calibnet-dev
+    #env_file:
+      ## Check envvars for configurable options
+      #- ./build/lily/docker.env
+    #depends_on:
+      #- prometheus
+      #- timescaledb
+      #- jaeger
+    #ports:
+      #- 1234:1234
+    #volumes:
+      #- lily_data:/var/lib/lily
+      #- ./build/lily/docker_init.sh:/usr/bin/docker_init.sh
+    #entrypoint: /usr/bin/docker_init.sh
+    #command:
+      #- daemon
+
 volumes:
   timescaledb: {}
   prometheus_data: {}


### PR DESCRIPTION
In order for users to quickly bootstrap lily completely within docker, I've added commented out stub and options to docker-compose setup.

Resolves https://github.com/filecoin-project/lily/pull/699#discussion_r728775964