### PR TITLE
fix: daemon api uses full flag value

### DIFF
--- a/commands/daemon.go
+++ b/commands/daemon.go
@@ -245,8 +245,7 @@ Note that jobs are not persisted between restarts of the daemon. See
 
 			node.ApplyIf(func(s *node.Settings) bool { return c.IsSet("api") },
 				node.Override(node.SetApiEndpointKey, func(lr repo.LockedRepo) error {
-					apima, err := multiaddr.NewMultiaddr("/ip4/127.0.0.1/tcp/" +
-						c.String("api"))
+					apima, err := multiaddr.NewMultiaddr(clientAPIFlags.apiAddr)
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
makes all commands work as expect with the API flag set as opposed to the daemon flag only expecting a port and other commands expecting a full multiaddress.

Changes doesn't interfere with docs: https://github.com/filecoin-project/sentinel/blob/master/docs/lily/operation.md#api-endpoint