### PR TITLE
Simplify gapfind hole detection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   dockerizer:
     docker:
-      - image: cimg/go:1.16.5
+      - image: cimg/go:1.16.6
     environment:
       IMAGE_NAME: filecoin/lily
   golang:
@@ -124,8 +124,8 @@ jobs:
   test:
     resource_class: large
     docker:
-      - image: cimg/go:1.16.5
-      - image: timescale/timescaledb:2.4.1-pg13
+      - image: cimg/go:1.16.6
+      - image: timescale/timescaledb:2.5.0-pg13
         environment:
           POSTGRES_PASSWORD: password
     steps:

--- a/chain/find.go
+++ b/chain/find.go
@@ -258,9 +258,9 @@ all_heights_and_tasks_in_range as (
 ,
 
 -- all heights from processing reports which were
--- recorded (by gap_fill or consensus) that it is
--- a null round with no data to index.
--- then take cross product of these heights w tasks
+-- recorded (by gap_fill or consensus) and are
+-- null rounds with no data to index.
+-- take cross product of these heights w tasks
 null_round_heights_and_tasks_in_range as (
 	select pr.height, t.task
 	from visor_processing_reports pr
@@ -274,22 +274,22 @@ null_round_heights_and_tasks_in_range as (
 -- all heights and tasks which need to be filled
 all_incomplete_heights_and_tasks as (
 
-	select height, task
 		-- starting from the set of all heights and tasks
 		-- in our range
-    from all_heights_and_tasks_in_range
+		select height, task
+		from all_heights_and_tasks_in_range
 
-    -- remove all heights and tasks which have at least one OK
-    except
-    select height, task
-    from visor_processing_reports
-    where status = ?3
+		-- remove all heights and tasks which have at least one OK
+		except
+		select height, task
+		from visor_processing_reports
+		where status = ?3
 		and height between ?0 and ?1
 
-    -- remove the null rounds by height and task
-    except
-    select height, task
-    from null_round_heights_and_tasks_in_range
+		-- remove the null rounds by height and task
+		except
+		select height, task
+		from null_round_heights_and_tasks_in_range
 )
 
 -- ordering for tidy persistence

--- a/chain/find_test.go
+++ b/chain/find_test.go
@@ -216,11 +216,12 @@ func TestFind(t *testing.T) {
 		mlens.On("ChainGetTipSetByHeight", mock.Anything, tsh2.Height(), types.EmptyTSK).
 			Return(tsh2, nil)
 
-		actual, err := NewGapIndexer(nil, strg, t.Name(), minHeight, maxHeight, AllTasks).
+		checkTasks := []string{ActorStatesMinerTask, ActorStatesInitTask}
+		actual, err := NewGapIndexer(nil, strg, t.Name(), uint64(2), uint64(2), checkTasks).
 			findTaskEpochGaps(ctx)
 		require.NoError(t, err)
 
-		expected := makeGapReportList(tsh2, ActorStatesMinerTask, ActorStatesInitTask)
+		expected := makeGapReportList(tsh2, checkTasks...)
 		assertGapReportsEqual(t, expected, actual)
 	})
 
@@ -242,11 +243,12 @@ func TestFind(t *testing.T) {
 		mlens.On("ChainGetTipSetByHeight", mock.Anything, tsh2.Height(), types.EmptyTSK).
 			Return(tsh2, nil)
 
-		actual, err := NewGapIndexer(nil, strg, t.Name(), minHeight, maxHeight, AllTasks).
+		checkTasks := []string{ActorStatesMinerTask, ActorStatesInitTask}
+		actual, err := NewGapIndexer(nil, strg, t.Name(), uint64(2), uint64(2), checkTasks).
 			findTaskEpochGaps(ctx)
 		require.NoError(t, err)
 
-		expected := makeGapReportList(tsh2, ActorStatesMinerTask, ActorStatesInitTask)
+		expected := makeGapReportList(tsh2, checkTasks...)
 		assertGapReportsEqual(t, expected, actual)
 	})
 
@@ -268,11 +270,12 @@ func TestFind(t *testing.T) {
 		mlens.On("ChainGetTipSetByHeight", mock.Anything, tsh2.Height(), types.EmptyTSK).
 			Return(tsh2, nil)
 
-		actual, err := NewGapIndexer(nil, strg, t.Name(), minHeight, maxHeight, AllTasks).
+		checkTasks := []string{ActorStatesMinerTask, ActorStatesInitTask}
+		actual, err := NewGapIndexer(nil, strg, t.Name(), uint64(2), uint64(2), checkTasks).
 			findTaskEpochGaps(ctx)
 		require.NoError(t, err)
 
-		expected := makeGapReportList(tsh2, ActorStatesMinerTask, ActorStatesInitTask)
+		expected := makeGapReportList(tsh2, checkTasks...)
 		assertGapReportsEqual(t, expected, actual)
 	})
 
@@ -329,7 +332,7 @@ type assertFields struct {
 func assertGapReportsEqual(t testing.TB, expected, actual visor.GapReportList) {
 	assert.Equal(t, len(expected), len(actual))
 	exp := make(map[int64][]assertFields, len(expected))
-	act := make(map[int64][]assertFields, len(expected))
+	act := make(map[int64][]assertFields, len(actual))
 
 	for _, e := range expected {
 		exp[e.Height] = append(exp[e.Height], assertFields{

--- a/chain/find_test.go
+++ b/chain/find_test.go
@@ -8,15 +8,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/filecoin-project/lily/model/visor"
 	"github.com/filecoin-project/lily/storage"
 	"github.com/filecoin-project/lily/testutil"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/go-pg/pg/v10"
-	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -412,23 +409,6 @@ type MockedFindLens struct {
 func (m *MockedFindLens) ChainGetTipSetByHeight(ctx context.Context, epoch abi.ChainEpoch, tsk types.TipSetKey) (*types.TipSet, error) {
 	args := m.Called(ctx, epoch, tsk)
 	return args.Get(0).(*types.TipSet), args.Error(1)
-}
-
-func fakeTipset(t testing.TB, height int) *types.TipSet {
-	bh := &types.BlockHeader{
-		Miner:                 address.TestAddress,
-		Height:                abi.ChainEpoch(height),
-		ParentStateRoot:       testutil.RandomCid(),
-		Parents:               []cid.Cid{testutil.RandomCid()},
-		Messages:              testutil.RandomCid(),
-		ParentMessageReceipts: testutil.RandomCid(),
-		BlockSig:              &crypto.Signature{Type: crypto.SigTypeBLS},
-		BLSAggregate:          &crypto.Signature{Type: crypto.SigTypeBLS},
-		Timestamp:             uint64(time.Now().Unix()),
-	}
-	ts, err := types.NewTipSet([]*types.BlockHeader{bh})
-	require.NoError(t, err)
-	return ts
 }
 
 type LoggingQueryHook struct{}


### PR DESCRIPTION
- removed bugs around edges cases
- this includes the diffing logic within the query which was previously happening after the query in go
- this logic appears to be complete according to spot checks in both directions (ensure this query points at heights that actually contain gaps as well as gaps manually perceived in visor reports which appear in the results of the query)
- gap find no longer writes NULL_ROUNDs to the processing reports table (this separates the concerns of fill and find more clearly, removes special cases for easier querying going forward, and had the side-effect of making test logic simpler)
- this speeds up execution (casual observations suggest around 10x improvement)

fixes #768 