### PR TITLE
Fix CI and testing deadlines

### DIFF
--- a/chain/walker_test.go
+++ b/chain/walker_test.go
@@ -21,7 +21,7 @@ func TestWalker(t *testing.T) {
 		t.Skip("short testing requested")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 	defer cancel()
 
 	db, cleanup, err := testutil.WaitForExclusiveDatabase(ctx, t)

--- a/storage/sql_test.go
+++ b/storage/sql_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/filecoin-project/lily/testutil"
 )
 
-const defaultDatabaseWaitTime = time.Second * 20
+const defaultDatabaseWaitTime = time.Minute * 1
 
 func TestConsistentSchemaMigrationSequence(t *testing.T) {
 	latestVersion := LatestSchemaVersion()


### PR DESCRIPTION
Breakage was caused by too short of timeouts, I am unsure what has caused their runtimes to increase in CI.