### PR TITLE
chore(find): Refactor GapIndexer.findMissingTasksAndEpochs

### DIFF
--- a/chain/find.go
+++ b/chain/find.go
@@ -2,14 +2,14 @@ package chain
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/deckarep/golang-set"
-	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/lily/lens"
 	"github.com/filecoin-project/lily/model/visor"
 	"github.com/filecoin-project/lily/storage"
-	"github.com/filecoin-project/lotus/chain/types"
 	"golang.org/x/xerrors"
 )
 
@@ -46,8 +46,6 @@ func NewGapIndexer(node lens.API, db *storage.Database, name string, minHeight, 
 }
 
 func (g *GapIndexer) Run(ctx context.Context) error {
-	startTime := time.Now()
-
 	head, err := g.node.ChainHead(ctx)
 	if err != nil {
 		return err
@@ -58,229 +56,159 @@ func (g *GapIndexer) Run(ctx context.Context) error {
 
 	findLog := log.With("type", "find")
 
-	// looks for incomplete epochs. An incomplete epoch has some, but not all tasks in the processing report table.
-	taskGaps, err := g.findTaskEpochGaps(ctx)
+	// looks for tasks within epochs which haven't sucessfully completed (at least 1 OK or NULL_ROUND)
+	taskGaps, err := g.findMissingEpochsAndTasks(ctx)
 	if err != nil {
 		return xerrors.Errorf("finding task epoch gaps: %w", err)
 	}
 	findLog.Infow("found gaps in tasks", "count", len(taskGaps))
-
-	// looks for missing epochs and null rounds. A missing epoch is a non-null-round height missing from the processing report table
-	heightGaps, nulls, err := g.findEpochGapsAndNullRounds(ctx, g.node)
-	if err != nil {
-		return xerrors.Errorf("finding epoch gaps: %w", err)
-	}
-	findLog.Infow("found gaps in epochs", "count", len(heightGaps))
-	findLog.Infow("found null rounds", "count", len(nulls))
-
-	// looks for entriest in the lily processing report table that have been skipped.
-	skipGaps, err := g.findEpochSkips(ctx)
-	if err != nil {
-		return xerrors.Errorf("detecting skipped gaps: %w", err)
-	}
-	findLog.Infow("found skipped epochs", "count", len(skipGaps))
-
-	var nullRounds visor.ProcessingReportList
-	for _, epoch := range nulls {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-		nullRounds = append(nullRounds, &visor.ProcessingReport{
-			Height:            int64(epoch),
-			StateRoot:         "NULL_ROUND", // let gap fill add the correct state root for this epoch when it runs the consensus task.
-			Reporter:          g.name,
-			Task:              "gap_find",
-			StartedAt:         startTime,
-			CompletedAt:       time.Now(),
-			Status:            visor.ProcessingStatusInfo,
-			StatusInformation: visor.ProcessingStatusInformationNullRound, // the gap finding logic uses this value to exclude null rounds from gap report.
-		})
-	}
-
-	return g.DB.PersistBatch(ctx, skipGaps, heightGaps, taskGaps, nullRounds)
+	return g.DB.PersistBatch(ctx, taskGaps)
 }
 
-type GapIndexerLens interface {
-	ChainGetTipSetByHeight(ctx context.Context, epoch abi.ChainEpoch, tsk types.TipSetKey) (*types.TipSet, error)
-}
-
-func (g *GapIndexer) findEpochSkips(ctx context.Context) (visor.GapReportList, error) {
-	log.Debug("finding skipped epochs")
-	reportTime := time.Now()
-
-	var skippedReports []visor.ProcessingReport
-	if err := g.DB.AsORM().ModelContext(ctx, &skippedReports).
-		Order("height desc").
-		Where("status = ?", visor.ProcessingStatusSkip).
-		Where("height >= ?", g.minHeight).
-		Where("height <= ?", g.maxHeight).
-		Select(); err != nil {
-		return nil, xerrors.Errorf("query processing report skips: %w", err)
-	}
-	log.Debugw("executed find skipped epoch query", "count", len(skippedReports))
-
-	gapReport := make([]*visor.GapReport, len(skippedReports))
-	for idx, r := range skippedReports {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
-		}
-		gapReport[idx] = &visor.GapReport{
-			Height:     r.Height,
-			Task:       r.Task,
-			Status:     "GAP",
-			Reporter:   g.name,
-			ReportedAt: reportTime,
-		}
-	}
-	return gapReport, nil
-}
-
-func (g *GapIndexer) findEpochGapsAndNullRounds(ctx context.Context, node GapIndexerLens) (visor.GapReportList, []abi.ChainEpoch, error) {
-	log.Debug("finding epoch gaps and null rounds")
-	reportTime := time.Now()
-
-	var nullRounds []abi.ChainEpoch
-	var missingHeights []uint64
-	res, err := g.DB.AsORM().QueryContext(
-		ctx,
-		&missingHeights,
-		`
-		SELECT s.i AS missing_epoch
-		FROM generate_series(?, ?) s(i)
-		WHERE NOT EXISTS (SELECT 1 FROM visor_processing_reports WHERE height = s.i);
-		`,
-		g.minHeight, g.maxHeight)
-	if err != nil {
-		return nil, nil, err
-	}
-	log.Debugw("executed find epoch gap query", "count", res.RowsReturned())
-
-	gapReport := make([]*visor.GapReport, 0, len(missingHeights))
-	// walk the possible gaps and query lotus to determine if gap was a null round or missed epoch.
-	for _, gap := range missingHeights {
-		select {
-		case <-ctx.Done():
-			return nil, nil, ctx.Err()
-		default:
-		}
-		gh := abi.ChainEpoch(gap)
-		tsgap, err := node.ChainGetTipSetByHeight(ctx, gh, types.EmptyTSK)
-		if err != nil {
-			return nil, nil, xerrors.Errorf("getting tipset by height %d: %w", gh, err)
-		}
-		if tsgap.Height() == gh {
-			log.Debugw("found gap", "height", gh)
-			for _, task := range AllTasks {
-				gapReport = append(gapReport, &visor.GapReport{
-					Height:     int64(tsgap.Height()),
-					Task:       task,
-					Status:     "GAP",
-					Reporter:   g.name,
-					ReportedAt: reportTime,
-				})
-			}
-		} else {
-			log.Debugw("found null round", "height", gh)
-			nullRounds = append(nullRounds, gh)
-		}
-	}
-	return gapReport, nullRounds, nil
-}
-
-type TaskHeight struct {
+type taskHeight struct {
 	Task   string
 	Height uint64
 	Status string
 }
 
-// TODO rather than use the length of `tasks` to determine where gaps are, use the contents to look for
-// gaps in specific task. Forrest' SQL-Foo isn't good enough for this yet.
-func (g *GapIndexer) findTaskEpochGaps(ctx context.Context) (visor.GapReportList, error) {
+func (g *GapIndexer) findMissingEpochsAndTasks(ctx context.Context) (visor.GapReportList, error) {
 	log.Debug("finding task epoch gaps")
 	start := time.Now()
-	var result []TaskHeight
+	var result []taskHeight
 	var out visor.GapReportList
-	// returns a list of tasks and heights for all incomplete heights
-	// and incomplete height is a height with less than len(tasks) entries, the tasks returned
-	// are the completed tasks for the height, we can diff them against all known tasks to find the
-	// missing ones.
+
+	var sqlFmtTaskValues []string
+	for t := range g.taskSet.Iter() {
+		sqlFmtTaskValues = append(sqlFmtTaskValues, fmt.Sprintf("('%s')", t))
+	}
+
+	// returns a list of tasks and heights for all incomplete heights and incomplete height
+	// is a height without an 'OK' or 'NULL_ROUND' for g.tasks. Returned values indicate
+	// heights and tasks which need to be filled.
+	query := fmt.Sprintf(`
+with
+
+-- generate all heights in range
+interesting_heights as (
+	select *
+	from generate_series(
+		?0,
+		?1
+	)
+	as x(height)
+)
+,
+
+-- enum all tasks for which we want to find gaps
+interesting_tasks as (
+	select *
+	from (values %s
+		-- example string (provided by sqlFmtTasks):
+		-- ('actorstatesraw'),
+		-- ('actorstatespower'),
+		-- ('actorstatesreward'),
+		-- ('actorstatesminer'),
+		-- ('actorstatesinit'),
+		-- ('actorstatesmarket'),
+		-- ('actorstatesmultisig'),
+		-- ('actorstatesverifreg'),
+		-- ('blocks'),
+		-- ('messages'),
+		-- ('chaineconomics'),
+		-- ('msapprovals'),
+		-- ('implicitmessage'),
+		-- ('consensus')
+	) as x(task)
+)
+,
+
+-- cross product of heights and tasks
+all_heights_and_tasks_in_range as (
+	select h.height, t.task
+	from interesting_heights h
+	cross join interesting_tasks t
+)
+,
+
+-- all heights from processing reports which were
+-- recorded (by gap_fill or consensus) that it is
+-- a null round with no data to index.
+-- then take cross product of these heights w tasks
+null_round_heights_and_tasks_in_range as (
+	select pr.height, t.task
+	from visor_processing_reports pr
+	cross join interesting_tasks t
+	where pr.status_information = ?3
+	and pr.height between ?0 and ?1
+	group by 1, 2
+)
+,
+
+-- all heights and tasks which need to be filled
+all_incomplete_heights_and_tasks as (
+
+	-- starting from the set of all heights and tasks
+	-- in our range
+	select height, task
+	from all_heights_and_tasks_in_range
+
+		except
+
+	-- remove all heights and tasks which have at least one OK
+	select height, task
+	from visor_processing_reports
+	where status = ?3
+	and height between ?0 and ?1
+
+		except
+
+	-- remove the null rounds by height and task
+	select height, task
+	from null_round_heights_and_tasks_in_range
+
+		except
+
+	-- remove all errors (to match the original behavior)
+	select height, task
+	from visor_processing_reports
+	where status = ?4
+	and height between ?0 and ?1
+)
+
+-- ordering for tidy persistence
+select height, task
+from all_incomplete_heights_and_tasks
+order by 1 desc
+;
+`, strings.Join(sqlFmtTaskValues, ","))
 	res, err := g.DB.AsORM().QueryContext(
 		ctx,
 		&result,
-		`
-select height, task
-from (
-         select distinct vpr.task, vpr.height, vpr.status_information
-         from visor_processing_reports vpr
-                  right join(
-             select height
-             from (
-                      select task_height_count.height, count(task_height_count.height) cheight
-                      from (
-                               select distinct(task) as task, height
-                               from visor_processing_reports
-                               group by height, task
-                               order by height desc
-                           ) task_height_count
-                      group by task_height_count.height
-                  ) task_count_per_height
-             where task_count_per_height.cheight != ?
-         ) incomplete
-                            on vpr.height = incomplete.height
-         where vpr.status_information != ?
-            or vpr.status_information is null
-     ) incomplete_heights_and_their_completed_tasks
-where height >= ? and height <= ?
-order by height desc
-`,
-		len(AllTasks), visor.ProcessingStatusInformationNullRound, g.minHeight, g.maxHeight,
+		query,
+		g.minHeight,
+		g.maxHeight,
+		visor.ProcessingStatusInformationNullRound,
+		visor.ProcessingStatusOK,
+		visor.ProcessingStatusError,
 	)
 	if err != nil {
 		return nil, err
 	}
-	log.Debugw("executed find task epoch gap query", "count", res.RowsReturned())
+	log.Debugw("executed find gap query and found epoch,task gaps", "count", res.RowsReturned())
 
-	// TODO the below could be replaced by creating a virtual table of all tasks and diffing
-	// the above results with the table to find missing tasks.
-
-	// result has all the tasks completed at each height, now we need to find what is missing
-	// at each height.
-	var CompletedTasksForHeight = make(map[uint64][]string)
-	for _, th := range result {
+	for _, r := range result {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		default:
 		}
-		CompletedTasksForHeight[th.Height] = append(CompletedTasksForHeight[th.Height], th.Task)
-	}
-
-	for height, tasks := range CompletedTasksForHeight {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
-		}
-		completedTasks := mapset.NewSet()
-		for _, t := range tasks {
-			completedTasks.Add(t)
-		}
-		missingTasks := FullTaskSet.Difference(completedTasks).Intersect(g.taskSet)
-		log.Debugw("found tasks with gaps", "height", height, "missing", missingTasks.String())
-		for mt := range missingTasks.Iter() {
-			missing := mt.(string)
-			out = append(out, &visor.GapReport{
-				Height:     int64(height),
-				Task:       missing,
-				Status:     "GAP",
-				Reporter:   g.name,
-				ReportedAt: start,
-			})
-		}
+		out = append(out, &visor.GapReport{
+			Height:     int64(r.Height),
+			Task:       r.Task,
+			Status:     "GAP",
+			Reporter:   g.name,
+			ReportedAt: start,
+		})
 	}
 	return out, nil
 }

--- a/chain/find_test.go
+++ b/chain/find_test.go
@@ -317,6 +317,23 @@ func TestFind(t *testing.T) {
 		expected := makeGapReportList(tsh2, MessagesTask, ActorStatesInitTask)
 		assertGapReportsEqual(t, expected, actual)
 	})
+
+	t.Run("(#773) for each task at epoch 2 there exists a SKIP and an OK", func(t *testing.T) {
+		truncateVPR(t, db)
+		initializeVPR(t, db, maxHeight, t.Name(), AllTasks...)
+		skipEpochSkippedVRP(t, db, 2, AllTasks...)
+		appendOKAtEpochVPR(t, db, 2, AllTasks...)
+
+		strg, err := storage.NewDatabaseFromDB(ctx, db, "public")
+		require.NoError(t, err, "NewDatabaseFromDB")
+
+		actual, err := NewGapIndexer(nil, strg, t.Name(), minHeight, maxHeight, AllTasks).
+			findMissingEpochsAndTasks(ctx)
+		require.NoError(t, err)
+
+		// no gaps should be found since the epoch has OK's for all tasks; the SKIPS are ignored.
+		require.Len(t, actual, 0)
+	})
 }
 
 type assertFields struct {
@@ -415,6 +432,17 @@ func skipEpochSkippedVRP(tb testing.TB, db *pg.DB, epoch int, tasks ...string) {
 	where height = ? and task = ?
 `,
 			epoch, task)
+		require.NoError(tb, err)
+	}
+}
+
+func appendOKAtEpochVPR(tb testing.TB, db *pg.DB, epoch int, tasks ...string) {
+	for _, task := range tasks {
+		qsrt := fmt.Sprintf(`
+	insert into public.visor_processing_reports(height, state_root, reporter, task, started_at, completed_at, status, status_information, errors_detected)
+	values(%d, concat(%d, '_state_root'), '%s_appendok', '%s', '2021-01-01 00:00:00.000000 +00:00', '2021-01-21 00:00:00.000000 +00:00', 'OK',null, null);
+			`, epoch, epoch, tb.Name(), task)
+		_, err := db.Exec(qsrt)
 		require.NoError(tb, err)
 	}
 }


### PR DESCRIPTION
Does not change the behavior of the tests, only tightens the expectations to only the subjects being tested.

Refactor happens to fix #773 as well, so this test is included.