### PR TITLE
chore: consolidate logger names

### DIFF
--- a/chain/actors/builtin/init/diff.go
+++ b/chain/actors/builtin/init/diff.go
@@ -15,7 +15,7 @@ import (
 	typegen "github.com/whyrusleeping/cbor-gen"
 )
 
-var log = logging.Logger("lily/actor/init")
+var log = logging.Logger("lily/actors")
 
 type AddressMapChanges struct {
 	Added    []AddressPair

--- a/chain/actors/builtin/market/diff.go
+++ b/chain/actors/builtin/market/diff.go
@@ -17,7 +17,7 @@ import (
 	"github.com/filecoin-project/lily/chain/actors/adt/diff"
 )
 
-var log = logging.Logger("lily/actors/market")
+var log = logging.Logger("lily/actors")
 
 func DiffDealProposals(ctx context.Context, store adt.Store, pre, cur State) (*DealProposalChanges, error) {
 	preOpts := pre.DealProposalsAmtBitwidth()

--- a/chain/export/export.go
+++ b/chain/export/export.go
@@ -17,7 +17,7 @@ import (
 	"gopkg.in/cheggaaa/pb.v1"
 )
 
-var log = logging.Logger("lily/chain/export")
+var log = logging.Logger("lily/chain")
 
 type ChainExporter struct {
 	store blockstore.Blockstore // blockstore chain is exported from

--- a/commands/util/rpc.go
+++ b/commands/util/rpc.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	log                = logging.Logger("util")
+	log                = logging.Logger("lily/commands")
 	Endpoint, _        = tag.NewKey("endpoint")
 	APIRequestDuration = stats.Float64("api/request_duration_ms", "Duration of API requests", stats.UnitMilliseconds)
 )

--- a/lens/lily/modules/statemanager.go
+++ b/lens/lily/modules/statemanager.go
@@ -17,7 +17,7 @@ import (
 	"golang.org/x/xerrors"
 )
 
-var log = logging.Logger("modules/statemanager")
+var log = logging.Logger("lily/lens")
 
 var ExecutionTraceNotFound = xerrors.Errorf("failed to find execution trace")
 

--- a/lens/lily/struct.go
+++ b/lens/lily/struct.go
@@ -16,7 +16,7 @@ import (
 	"github.com/filecoin-project/lily/schedule"
 )
 
-var log = logging.Logger("lily/lens/lily")
+var log = logging.Logger("lily/lens")
 
 var _ LilyAPI = (*LilyAPIStruct)(nil)
 

--- a/lens/util/repo.go
+++ b/lens/util/repo.go
@@ -23,7 +23,7 @@ import (
 	"github.com/filecoin-project/lily/tasks/messages/fcjson"
 )
 
-var log = logging.Logger("lens/util")
+var log = logging.Logger("lily/lens")
 
 // GetMessagesForTipset returns a list of messages sent as part of pts (parent) with receipts found in ts (child).
 // No attempt at deduplication of messages is made. A list of blocks with their corresponding messages is also returned - it contains all messages

--- a/network/surveyer.go
+++ b/network/surveyer.go
@@ -19,7 +19,7 @@ const (
 	PeerAgentsTask = "peeragents" // task that observes connected peer agents
 )
 
-var log = logging.Logger("visor/network")
+var log = logging.Logger("lily/network")
 
 type API interface {
 	peeragents.API

--- a/tasks/actorstate/actorstate.go
+++ b/tasks/actorstate/actorstate.go
@@ -16,7 +16,7 @@ import (
 	"github.com/filecoin-project/lily/model"
 )
 
-var log = logging.Logger("lily/task/actorstate")
+var log = logging.Logger("lily/tasks")
 
 type ActorInfo struct {
 	Actor           types.Actor

--- a/tasks/chaineconomics/task.go
+++ b/tasks/chaineconomics/task.go
@@ -11,7 +11,7 @@ import (
 	visormodel "github.com/filecoin-project/lily/model/visor"
 )
 
-var log = logging.Logger("lily/task/chaineconomics")
+var log = logging.Logger("lily/tasks")
 
 type Task struct {
 	node lens.API

--- a/tasks/messages/message.go
+++ b/tasks/messages/message.go
@@ -26,7 +26,7 @@ import (
 	"github.com/filecoin-project/lily/tasks/messages/fcjson"
 )
 
-var log = logging.Logger("lily/task/messages")
+var log = logging.Logger("lily/tasks")
 
 type Task struct{}
 

--- a/tasks/survey/peeragents/peeragents.go
+++ b/tasks/survey/peeragents/peeragents.go
@@ -13,7 +13,7 @@ import (
 	"github.com/filecoin-project/lily/model/surveyed"
 )
 
-var log = logging.Logger("visor/task/peeragents")
+var log = logging.Logger("visor/tasks")
 
 type API interface {
 	ID(ctx context.Context) (peer.ID, error)


### PR DESCRIPTION
This consolidates logger names so we have fewer to manage. Since Lotus is very chatty we often set all logging to error level and selectively lower the level to info or debug for loggers of interest (for example: `--log-level=error --log-level-named=lily/chain:debug,lily/storage:debug,lily/schedule:debug,lens/util:debug,chain:info,badgerbs:info`). There were several loggers that logged only in one or two places but had their own obscure composite name (e.g. `lily/lens/lily`)

I've followed the general principle of naming loggers as `lily/` followed by the top level package name. This hopefully will be somewhat robust against refactoring inner packages over time.

The main exception is `lily/actors` which is found in the `chain/actors` package, but I think we ought to move that to its own top level package. I'm leaving that as a separate exercise.

Fixed a couple of logger names that were not prefixed with `lily`

We only have these loggers now:

- lily/main
- lily/chain
- lily/actors
- lily/commands
- lily/config
- lily/lens
- lily/network
- lily/storage
- lily/tasks


