### PR TITLE
fix(tests): Ensembleminimal requires mocker proofs

### DIFF
--- a/chain/walker_test.go
+++ b/chain/walker_test.go
@@ -33,7 +33,7 @@ func TestWalker(t *testing.T) {
 	require.NoError(t, err, "truncating tables")
 
 	t.Logf("preparing chain")
-	full, miner, _ := itestkit.EnsembleMinimal(t)
+	full, miner, _ := itestkit.EnsembleMinimal(t, itestkit.MockProofs())
 
 	nodeAPI := testutil.NewAPIWrapper(full)
 

--- a/chain/watcher_test.go
+++ b/chain/watcher_test.go
@@ -60,7 +60,7 @@ func TestWatcher(t *testing.T) {
 	require.NoError(t, err, "truncating tables")
 
 	t.Logf("preparing chain")
-	full, miner, _ := itestkit.EnsembleMinimal(t)
+	full, miner, _ := itestkit.EnsembleMinimal(t, itestkit.MockProofs())
 
 	nodeAPI := testutil.NewAPIWrapper(full)
 


### PR DESCRIPTION
Really weird and concerning this ever passed in CI but not locally.

This appears to be related to M1 macbooks and proof parameters