### PR TITLE
Generic in memory lily testing via vectors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,44 @@ jobs:
           file: /tmp/artifacts/coverage.out
       - store_artifacts:
           path: lily
+  integration-test:
+    resource_class: large
+    docker:
+      - image: cimg/go:1.16.6
+      - image: timescale/timescaledb:2.5.0-pg13
+        environment:
+          POSTGRES_PASSWORD: password
+    steps:
+      - checkout
+      - prepare
+      - run: # dep for DB wait script
+          name: install dockerize
+          command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+          environment:
+            DOCKERIZE_VERSION: v0.3.0
+      - run: sudo apt-get update
+      - run: make deps
+      - run: make build
+      - run:
+          name: waiting for db
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+      - run:
+          name: installing schema
+          command: ./lily migrate --latest
+          environment:
+            LILY_DB: postgres://postgres:password@localhost:5432/postgres?sslmode=disable
+      - restore_cache:
+          name: restore test vectors cache
+          key: lily-test-vectors-{{ checksum "./build/test-vectors/vectors.json" }}
+          paths:
+            - /var/tmp/lily-test-vectors/
+      - run:
+          command: make itest-calibnet
+      - save_cache:
+          name: save test vectors cache
+          key: lily-test-vectors-{{ checksum "./build/test-vectors/vectors.json" }}
+          paths:
+            - /var/tmp/lily-test-vectors/
   lint: &lint
     description: |
       Run golangci-lint.
@@ -252,6 +290,7 @@ workflows:
       - mod-tidy-check
       - lint-all
       - test
+      - integration-test
       - test-docker-mainnet
       - test-docker-mainnet-dev
       - test-docker-calibnet

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,7 @@ jobs:
           paths:
             - /var/tmp/lily-test-vectors/
       - run:
-          command: make itest-calibnet
+          command: make itest
       - save_cache:
           name: save test vectors cache
           key: lily-test-vectors-{{ checksum "./build/test-vectors/vectors.json" }}

--- a/Makefile
+++ b/Makefile
@@ -126,9 +126,9 @@ actors-gen:
 	go run ./chain/actors/agen
 	go fmt ./...
 
-.PHONY: itest-calibnet
-itest-calibnet:
-	LILY_TEST_DB="postgres://postgres:password@localhost:5432/postgres?sslmode=disable" go test -tags=calibnet ./itests/
+.PHONY: itest
+itest:
+	LILY_TEST_DB="postgres://postgres:password@localhost:5432/postgres?sslmode=disable" go test ./itests/
 
 # dev-nets
 2k: GOFLAGS+=-tags=2k

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ testfull: build
 testshort:
 	go test -short ./... -v
 
+
 .PHONY: lily
 lily:
 	rm -f lily
@@ -125,6 +126,9 @@ actors-gen:
 	go run ./chain/actors/agen
 	go fmt ./...
 
+.PHONY: itest-calibnet
+itest-calibnet:
+	LILY_TEST_DB="postgres://postgres:password@localhost:5432/postgres?sslmode=disable" go test -tags=calibnet ./itests/
 
 # dev-nets
 2k: GOFLAGS+=-tags=2k

--- a/build/test-vectors/README.md
+++ b/build/test-vectors/README.md
@@ -1,13 +1,18 @@
-# Test Vectors
-This directory contains the test vector manuscript.
-Add new test vectors by appending them to `vectors.json`.
-Execute `make itest-<network_name>` to download and execute vector tests.
-The contents of the `vectors.json` must contain the following:
-- `"file_name"`
-  - `cid`: The CID of a car file produced by running a chain export.
-  - `network`: The network the CAR file was exported from.
-  - `digest`: Sha256 of CAR file, eg. `shasum -a 256 chain.car`.
-  - `from`: earliest full state epoch.
-  - `to`: latest full state epoch.
-
-Vectors are downloaded to `LILY_TEST_VECTORS` defaulting to `/var/temp/lily-test-vectors` based on network name.
+### How to add a new vector
+1. Create a CAR file for the chain snapshot being vectorized called "snapshot.car"
+2. Create a CAR file for the genesis block of the snapshot called "genesis.car"
+3. TAR the two files `tar -cvf <network>-<start_epoch>-<end_epoch>-fullstate.tar snapshot.car genesis.car`
+4. Add the TAR file to IPFS (be sure its pinned somewhere, like web3.storage or estuary.tech)
+5. Sha256 the TAR file `shasum -a 256 <network>-<start_epoch>-<end_epoch>-fullstate.tar`
+6. Add an entry to `vectors.json`, the object key must not collide with an existing one:
+```json
+{
+  "<network>-<start_epoch>-<end_epoch>-fullstate.tar": {
+    "cid": "<cid_of_tar_file>",
+    "network": "<network_snapshot_was_exported_from",
+    "digest": "<sha256_of_tar_file_from_step_5>",
+    "from": "<first_full_state_epoch_of_snapshot",
+    "to": "<head_epoch_of_snapshot>"
+  }
+}
+```

--- a/build/test-vectors/README.md
+++ b/build/test-vectors/README.md
@@ -1,0 +1,13 @@
+# Test Vectors
+This directory contains the test vector manuscript.
+Add new test vectors by appending them to `vectors.json`.
+Execute `make itest-<network_name>` to download and execute vector tests.
+The contents of the `vectors.json` must contain the following:
+- `"file_name"`
+  - `cid`: The CID of a car file produced by running a chain export.
+  - `network`: The network the CAR file was exported from.
+  - `digest`: Sha256 of CAR file, eg. `shasum -a 256 chain.car`.
+  - `from`: earliest full state epoch.
+  - `to`: latest full state epoch.
+
+Vectors are downloaded to `LILY_TEST_VECTORS` defaulting to `/var/temp/lily-test-vectors` based on network name.

--- a/build/test-vectors/vectors.json
+++ b/build/test-vectors/vectors.json
@@ -1,0 +1,16 @@
+{
+  "calibration-0-1000-fullstate.car": {
+    "cid": "bafybeih2qz4g7twt5jhvokcggbq47gunkepeeealy7ydfpks2k4cga4qiy",
+    "network": "calibnet",
+    "digest": "1bcc960e24a1d7b89640163a0b67d7e7aa6421f150ded348bd6bf982045f3528",
+    "from": 0,
+    "to": 1000
+  },
+  "calibration-2001-3000-fullstate.car": {
+    "cid": "bafybeigu6yogvansi5vhzinyujlhqpsu7wczycc7awfbo24hhlpl25kule",
+    "network": "calibnet",
+    "digest":"1324f5e1847629e43d5d14fbe81d1b398d142d5fc63d2a3ce5aff63ec3525e62",
+    "from": 2001,
+    "to": 3000
+  }
+}

--- a/build/test-vectors/vectors.json
+++ b/build/test-vectors/vectors.json
@@ -1,15 +1,15 @@
 {
-  "calibration-0-1000-fullstate.car": {
-    "cid": "bafybeih2qz4g7twt5jhvokcggbq47gunkepeeealy7ydfpks2k4cga4qiy",
+  "calibration-0-1000-fullstate.tar": {
+    "cid": "bafybeic36tvrem2pybcp6ksmwmpb4r6rth66cdnqbmssuiyjdkgnv2c2he",
     "network": "calibnet",
-    "digest": "1bcc960e24a1d7b89640163a0b67d7e7aa6421f150ded348bd6bf982045f3528",
+    "digest": "c7b29ce1451c40db56e5e88bbdb0ab197a4f85e566473abf576fcd954a8136fa",
     "from": 0,
     "to": 1000
   },
-  "calibration-2001-3000-fullstate.car": {
-    "cid": "bafybeigu6yogvansi5vhzinyujlhqpsu7wczycc7awfbo24hhlpl25kule",
+  "calibration-2001-3000-fullstate.tar": {
+    "cid": "bafybeihbsanrvwtrcecycmjry7lvh3fbrjvxltncxj2g7l3bnwuhvzpwwy",
     "network": "calibnet",
-    "digest":"1324f5e1847629e43d5d14fbe81d1b398d142d5fc63d2a3ce5aff63ec3525e62",
+    "digest":"461fb317550d9bc2fcb24cc76a432f5df3697dd69dfb021e1982077fd03baa0e",
     "from": 2001,
     "to": 3000
   }

--- a/build/vector_params.go
+++ b/build/vector_params.go
@@ -1,0 +1,10 @@
+package build
+
+import _ "embed"
+
+//go:embed test-vectors/vectors.json
+var vectors []byte
+
+func VectorsJSON() []byte {
+	return vectors
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.5'
 services:
   timescaledb:
     container_name: timescaledb
-    image: timescale/timescaledb:2.4.1-pg13
+    image: timescale/timescaledb:2.5.0-pg13
     ports:
       - "5432:5432"
     environment:

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/ipfs/go-block-format v0.0.3
 	github.com/ipfs/go-cid v0.1.0
+	github.com/ipfs/go-fs-lock v0.0.6
 	github.com/ipfs/go-ipfs-blockstore v1.0.4
 	github.com/ipfs/go-ipld-cbor v0.0.5
 	github.com/ipfs/go-log/v2 v2.3.0
@@ -55,6 +56,7 @@ require (
 	go.opentelemetry.io/otel/exporters/jaeger v1.2.0
 	go.opentelemetry.io/otel/sdk v1.2.0
 	go.uber.org/fx v1.15.0
+	go.uber.org/multierr v1.7.0
 	go.uber.org/zap v1.19.0
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/cheggaaa/pb.v1 v1.0.28

--- a/itests/builder.go
+++ b/itests/builder.go
@@ -1,0 +1,440 @@
+package itests
+
+import (
+	"context"
+	"fmt"
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/lily/config"
+	"github.com/filecoin-project/lily/lens"
+	"github.com/filecoin-project/lily/lens/lily"
+	lutil "github.com/filecoin-project/lily/lens/util"
+	"github.com/filecoin-project/lily/storage"
+	api2 "github.com/filecoin-project/lotus/api"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/lotus/node"
+	"github.com/go-pg/pg/v10"
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
+	"io/fs"
+	"testing"
+	"time"
+)
+
+type VectorWalkValidatorBuilder struct {
+	options []func(tv *VectorWalkValidator)
+	vector  fs.File
+}
+
+func NewVectorWalkValidatorBuilder(fs fs.File) VectorWalkValidatorBuilder {
+	var b VectorWalkValidatorBuilder
+	b.vector = fs
+	return b
+}
+
+func (b *VectorWalkValidatorBuilder) add(cb func(vector *VectorWalkValidator)) {
+	b.options = append(b.options, cb)
+}
+
+func (b VectorWalkValidatorBuilder) WithDatabase(strg *storage.Database) VectorWalkValidatorBuilder {
+	b.add(func(tv *VectorWalkValidator) {
+		tv.strg = strg
+	})
+	return b
+}
+
+func (b VectorWalkValidatorBuilder) WithRange(from, to int64) VectorWalkValidatorBuilder {
+	b.add(func(vw *VectorWalkValidator) {
+		vw.from = from
+		vw.to = to
+	})
+	return b
+}
+
+func (b VectorWalkValidatorBuilder) WithTasks(tasks ...string) VectorWalkValidatorBuilder {
+	b.add(func(vw *VectorWalkValidator) {
+		vw.tasks = tasks
+	})
+	return b
+}
+
+func (b VectorWalkValidatorBuilder) WithNodeCfg(cfg *TestNodeConfig) VectorWalkValidatorBuilder {
+	b.add(func(vw *VectorWalkValidator) {
+		vw.lilyCfg = cfg
+	})
+	return b
+}
+
+func (b VectorWalkValidatorBuilder) Build(ctx context.Context, t testing.TB) *VectorWalkValidator {
+	def := config.DefaultConf()
+	ncfg := *def
+	storageName := "TestDatabase1"
+	ncfg.Storage = config.StorageConf{
+		Postgresql: map[string]config.PgStorageConf{
+			storageName: {
+				URLEnv:          "LILY_TEST_DB",
+				PoolSize:        20,
+				ApplicationName: "lily-itests",
+				AllowUpsert:     false,
+				SchemaName:      "public",
+			},
+		},
+	}
+
+	lilyCfg := &TestNodeConfig{
+		LilyConfig: &ncfg,
+		CacheConfig: &lutil.CacheConfig{
+			BlockstoreCacheSize: 0,
+			StatestoreCacheSize: 0,
+		},
+		RepoPath:    t.TempDir(),
+		Snapshot:    b.vector,
+		ApiEndpoint: "/ip4/127.0.0.1/tcp/4321",
+	}
+
+	vw := &VectorWalkValidator{
+		ctx:     ctx,
+		t:       t,
+		vector:  b.vector,
+		strg:    nil,
+		from:    0,
+		to:      0,
+		tasks:   nil,
+		lilyCfg: lilyCfg,
+	}
+
+	for _, opt := range b.options {
+		opt(vw)
+	}
+
+	if vw.strg == nil {
+		t.Fatal("storage required")
+	}
+	if vw.tasks == nil {
+		t.Fatal("tasks required")
+	}
+	if vw.lilyCfg == nil {
+		t.Fatal("lily config required")
+	}
+	for _, task := range vw.tasks {
+		models, ok := TaskModels[task]
+		if !ok {
+			t.Fatalf("no models for task: %s", task)
+		}
+		truncateTable(t, vw.strg.AsORM(), models...)
+	}
+	// always truncate this table
+	truncateTable(t, vw.strg.AsORM(), "visor_processing_reports")
+
+	return vw
+}
+
+type VectorWalkValidator struct {
+	ctx      context.Context
+	t        testing.TB
+	vector   fs.File
+	strg     *storage.Database
+	from, to int64
+	tasks    []string
+	lilyCfg  *TestNodeConfig
+	api      *lily.LilyNodeAPI
+}
+
+func (vw *VectorWalkValidator) Run(ctx context.Context) node.StopFunc {
+	// start the lily node
+	lilyAPI, apiCleanup := NewTestNode(vw.t, ctx, vw.lilyCfg)
+	api := lilyAPI.(*lily.LilyNodeAPI)
+	vw.api = api
+
+	// create a walk config from the builder values
+	walkCfg := &lily.LilyWalkConfig{
+		From:                vw.from,
+		To:                  vw.to,
+		Name:                vw.t.Name(),
+		Tasks:               vw.tasks,
+		Window:              0,
+		RestartOnFailure:    false,
+		RestartOnCompletion: false,
+		RestartDelay:        0,
+		Storage:             "TestDatabase1",
+	}
+
+	walkStart := time.Now()
+	// walk that walk
+	vw.t.Logf("starting walk from %d to %d with tasks %s", walkCfg.From, walkCfg.To, walkCfg.Tasks)
+	res, err := vw.api.LilyWalk(ctx, walkCfg)
+	require.NoError(vw.t, err)
+	require.NotEmpty(vw.t, res)
+
+	vw.t.Log("waiting for walk to complete")
+	// wait for the job to get to the scheduler else the job ID isn't found
+	time.Sleep(3 * time.Second)
+	// wait for the walk to complete
+	ress, err := vw.api.LilyJobWait(ctx, res.ID)
+	require.NoError(vw.t, err)
+	require.NotEmpty(vw.t, ress)
+
+	vw.t.Logf("walk from %d to %d took %s", vw.from, vw.to, time.Since(walkStart))
+
+	vw.t.Log("waiting for persistence to complete")
+	// wait for persistence to complete
+	time.Sleep(3 * time.Second)
+	return apiCleanup
+}
+
+func (vw *VectorWalkValidator) Validate(t *testing.T) {
+	var tsv []TipSetStateValidator
+	var epv []EpochValidator
+	for _, task := range vw.tasks {
+		taskValidators, ok := TaskValidators[task]
+		if !ok {
+			t.Fatal("no validators for task", task)
+		}
+		for _, validator := range taskValidators {
+			switch v := validator.(type) {
+			case TipSetStateValidator:
+				tsv = append(tsv, v)
+			case EpochValidator:
+				epv = append(epv, v)
+			default:
+				t.Fatalf("unknown validator type: %T", v)
+			}
+		}
+	}
+	if len(tsv) > 0 {
+		vw.ValidateTipSetStates(t, tsv...)
+	}
+	if len(epv) > 0 {
+		vw.ValidateEpochState(t, epv...)
+	}
+}
+
+func (vw *VectorWalkValidator) ValidateEpochState(t *testing.T, mv ...EpochValidator) {
+	t.Run("validate epoch states", func(t *testing.T) {
+
+		walkHead, err := vw.api.ChainGetTipSetByHeight(vw.ctx, abi.ChainEpoch(vw.to), types.EmptyTSK)
+		require.NoError(vw.t, err)
+
+		if int64(walkHead.Height()) != vw.to {
+			// TODO
+			t.Fatal("TODO to was a null round, not handled yet")
+		}
+
+		tss, err := collectEpochsWithNullRoundsRange(vw.ctx, vw.api, vw.from, vw.to)
+		require.NoError(vw.t, err)
+
+		for epoch := vw.from; epoch <= vw.to; epoch++ {
+			for _, m := range mv {
+				m.Validate(t, epoch, tss[epoch], vw.strg, vw.api)
+			}
+		}
+	})
+}
+
+// ValidateModels validates that the data in the database for the passed models matches the results returned by the lotus api.
+func (vw *VectorWalkValidator) ValidateTipSetStates(t *testing.T, mv ...TipSetStateValidator) {
+	t.Run("validate tipset states", func(t *testing.T) {
+		walkHead, err := vw.api.ChainGetTipSetByHeight(vw.ctx, abi.ChainEpoch(vw.to), types.EmptyTSK)
+		require.NoError(vw.t, err)
+
+		if int64(walkHead.Height()) != vw.to {
+			// TODO
+			t.Fatal("TODO to was a null round, not handled yet")
+		}
+
+		tss, err := collectTipSetRange(vw.ctx, vw.api, vw.from, vw.to)
+		require.NoError(vw.t, err)
+
+		for _, ts := range tss {
+			if ts.Height() < abi.ChainEpoch(vw.from) {
+				break
+			}
+			tsState, err := StateForTipSet(vw.ctx, vw.api, ts)
+			require.NoError(vw.t, err)
+
+			for _, m := range mv {
+				m.Validate(t, tsState, vw.strg)
+			}
+		}
+	})
+}
+
+// TipSetState contains the state of actors, blocks, messages, and receipts for the tipset it was derived from.
+type TipSetState struct {
+	ts *types.TipSet
+	// actors changed whiloe producing this tipset
+	actorsChanges map[address.Address]types.Actor
+	// blocks in this tipset
+	blocks []*types.BlockHeader
+	// messages in the blocks of this TipSet (will contain duplicate messages)
+	blockMsgs map[*types.BlockHeader]*api2.BlockMessages
+	// messages and their receipts
+	msgRects map[cid.Cid]*types.MessageReceipt
+}
+
+// actorsFromGenesisBlock returns the set of actors found in the genesis block.
+func actorsFromGenesisBlock(ctx context.Context, n *lily.LilyNodeAPI, ts *types.TipSet) (map[address.Address]types.Actor, error) {
+	actors, err := n.StateListActors(ctx, ts.Key())
+	if err != nil {
+		return nil, err
+	}
+
+	actorsChanged := make(map[address.Address]types.Actor)
+	for _, addr := range actors {
+		act, err := n.StateGetActor(ctx, addr, ts.Key())
+		if err != nil {
+			return nil, err
+		}
+		actorsChanged[addr] = *act
+	}
+	return actorsChanged, nil
+}
+
+// StateForTipSet returns a TipSetState for TipSet `ts`. All state is derived from Lotus API calls.
+func StateForTipSet(ctx context.Context, n *lily.LilyNodeAPI, ts *types.TipSet) (*TipSetState, error) {
+	pts, err := n.ChainGetTipSet(ctx, ts.Parents())
+	if err != nil {
+		return nil, err
+	}
+
+	actorsChanged := make(map[address.Address]types.Actor)
+	if pts.Height() == 0 {
+		actorsChanged, err = actorsFromGenesisBlock(ctx, n, ts)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// the actors who changed while producing this tipset
+		tsActorChanges, err := n.StateChangedActors(ctx, pts.ParentState(), ts.ParentState())
+		if err != nil {
+			return nil, err
+		}
+
+		for addrStr, act := range tsActorChanges {
+			addr, err := address.NewFromString(addrStr)
+			if err != nil {
+				return nil, err
+			}
+			actorsChanged[addr] = act
+		}
+	}
+
+	// messages from the parent tipset, their receipts will be in (child) ts
+	parentMessages, err := n.ChainAPI.Chain.MessagesForTipset(pts)
+	if err != nil {
+		return nil, err
+	}
+
+	blkMsgs := make(map[*types.BlockHeader]*api2.BlockMessages)
+	msgRects := make(map[cid.Cid]*types.MessageReceipt)
+	for _, blk := range ts.Blocks() {
+		// map of blocks to their messages
+		msgs, err := n.ChainGetBlockMessages(ctx, blk.Cid())
+		if err != nil {
+			return nil, err
+		}
+		blkMsgs[blk] = msgs
+
+		// map of parent messages to their receipts
+		for i := 0; i < len(parentMessages); i++ {
+			r, err := n.ChainAPI.Chain.GetParentReceipt(blk, i)
+			if err != nil {
+				return nil, err
+			}
+			msgRects[parentMessages[i].Cid()] = r
+		}
+
+	}
+
+	return &TipSetState{
+		ts:            ts,
+		actorsChanges: actorsChanged,
+		blocks:        ts.Blocks(),
+		blockMsgs:     blkMsgs,
+		msgRects:      msgRects,
+	}, nil
+}
+
+func collectEpochsWithNullRoundsRange(ctx context.Context, api lens.API, from, to int64) (map[int64]*types.TipSet, error) {
+	head, err := api.ChainGetTipSetByHeight(ctx, abi.ChainEpoch(to), types.EmptyTSK)
+	if err != nil {
+		return nil, err
+	}
+	if int64(head.Height()) != to {
+		// TODO
+		return nil, xerrors.Errorf("TODO to (%d) was a null round, not handled yet", to)
+	}
+
+	tail, err := api.ChainGetTipSetByHeight(ctx, abi.ChainEpoch(from), types.EmptyTSK)
+	if err != nil {
+		return nil, err
+	}
+	if int64(tail.Height()) != from {
+		// TODO
+		return nil, xerrors.Errorf("TODO from (%d) was a null round, not handled yet", from)
+	}
+
+	out := make(map[int64]*types.TipSet)
+
+	current := head
+	for {
+		out[int64(current.Height())] = current
+		parent, err := api.ChainGetTipSet(ctx, current.Parents())
+		if err != nil {
+			return nil, err
+		}
+		current = parent
+		if current.Height() == tail.Height() {
+			out[int64(current.Height())] = current
+			break
+		}
+	}
+	return out, nil
+
+}
+
+func collectTipSetRange(ctx context.Context, api lens.API, from, to int64) ([]*types.TipSet, error) {
+	head, err := api.ChainGetTipSetByHeight(ctx, abi.ChainEpoch(to), types.EmptyTSK)
+	if err != nil {
+		return nil, err
+	}
+	if int64(head.Height()) != to {
+		// TODO
+		return nil, xerrors.Errorf("TODO to (%d) was a null round, not handled yet", to)
+	}
+
+	tail, err := api.ChainGetTipSetByHeight(ctx, abi.ChainEpoch(from), types.EmptyTSK)
+	if err != nil {
+		return nil, err
+	}
+	if int64(tail.Height()) != from {
+		// TODO
+		return nil, xerrors.Errorf("TODO from (%d) was a null round, not handled yet", from)
+	}
+
+	out := make([]*types.TipSet, 0, head.Height()-tail.Height())
+
+	current := head
+	for {
+		parent, err := api.ChainGetTipSet(ctx, current.Parents())
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, current)
+		current = parent
+		if current.Height() == tail.Height() {
+			break
+		}
+	}
+	return out, nil
+
+}
+
+// truncateTables ensures the tables are truncated
+func truncateTable(tb testing.TB, db *pg.DB, tableNames ...string) {
+	for _, table := range tableNames {
+		_, err := db.Exec(fmt.Sprintf("TRUNCATE TABLE %s", table))
+		require.NoError(tb, err, table)
+	}
+}

--- a/itests/builder.go
+++ b/itests/builder.go
@@ -17,19 +17,18 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/xerrors"
-	"io/fs"
 	"testing"
 	"time"
 )
 
 type VectorWalkValidatorBuilder struct {
 	options []func(tv *VectorWalkValidator)
-	vector  fs.File
+	vector  *TestVector
 }
 
-func NewVectorWalkValidatorBuilder(fs fs.File) VectorWalkValidatorBuilder {
+func NewVectorWalkValidatorBuilder(tv *TestVector) VectorWalkValidatorBuilder {
 	var b VectorWalkValidatorBuilder
-	b.vector = fs
+	b.vector = tv
 	return b
 }
 
@@ -89,14 +88,14 @@ func (b VectorWalkValidatorBuilder) Build(ctx context.Context, t testing.TB) *Ve
 			StatestoreCacheSize: 0,
 		},
 		RepoPath:    t.TempDir(),
-		Snapshot:    b.vector,
+		Snapshot:    b.vector.Snapshot,
+		Genesis:     b.vector.Genesis,
 		ApiEndpoint: "/ip4/127.0.0.1/tcp/4321",
 	}
 
 	vw := &VectorWalkValidator{
 		ctx:     ctx,
 		t:       t,
-		vector:  b.vector,
 		strg:    nil,
 		from:    0,
 		to:      0,
@@ -133,7 +132,6 @@ func (b VectorWalkValidatorBuilder) Build(ctx context.Context, t testing.TB) *Ve
 type VectorWalkValidator struct {
 	ctx      context.Context
 	t        testing.TB
-	vector   fs.File
 	strg     *storage.Database
 	from, to int64
 	tasks    []string

--- a/itests/fetch/fetch.go
+++ b/itests/fetch/fetch.go
@@ -22,6 +22,8 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 )
 
+// Ported from github.com/filecoin-project/go-paramfetch
+
 var log = logging.Logger("lily/vectors")
 
 const gateway = "https://dweb.link/ipfs/"

--- a/itests/fetch/fetch.go
+++ b/itests/fetch/fetch.go
@@ -1,0 +1,246 @@
+package fetch
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+
+	"go.uber.org/multierr"
+	"golang.org/x/xerrors"
+	"gopkg.in/cheggaaa/pb.v1"
+
+	fslock "github.com/ipfs/go-fs-lock"
+	logging "github.com/ipfs/go-log/v2"
+)
+
+var log = logging.Logger("lily/vectors")
+
+const gateway = "https://dweb.link/ipfs/"
+const lockFile = "fetch.lock"
+const vectordir = "/var/tmp/lily-test-vectors"
+const vectordirenv = "LILY_TEST_VECTORS"
+const lockRetry = time.Second * 10
+
+func GetVectorDir() string {
+	if os.Getenv(vectordirenv) == "" {
+		return vectordir
+	}
+	return os.Getenv(vectordirenv)
+}
+
+var checked = map[string]struct{}{}
+var checkedLk sync.Mutex
+
+type VectorFile struct {
+	Cid     string `json:"cid"`
+	Network string `json:"network"`
+	Digest  string `json:"digest"`
+	From    int64  `json:"from"`
+	To      int64  `json:"to"`
+}
+
+func GetVectors(ctx context.Context, vectorBytes []byte) error {
+	if err := os.Mkdir(GetVectorDir(), 0755); err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	var testVectors map[string]VectorFile
+
+	if err := json.Unmarshal(vectorBytes, &testVectors); err != nil {
+		return err
+	}
+
+	ft := &fetch{}
+	for name, info := range testVectors {
+		if err := os.Mkdir(filepath.Join(GetVectorDir(), info.Network), 0755); err != nil && !os.IsExist(err) {
+			return err
+		}
+		ft.fetchAsync(ctx, name, info)
+	}
+
+	return ft.wait(ctx)
+}
+
+type fetch struct {
+	wg      sync.WaitGroup
+	fetchLk sync.Mutex
+
+	errs []error
+}
+
+func (ft *fetch) fetchAsync(ctx context.Context, name string, info VectorFile) {
+	ft.wg.Add(1)
+
+	go func() {
+		defer ft.wg.Done()
+
+		path := filepath.Join(GetVectorDir(), filepath.Join(info.Network, name))
+
+		err := ft.checkFile(path, info)
+		if !os.IsNotExist(err) && err != nil {
+			log.Warn(err)
+		}
+		if err == nil {
+			return
+		}
+
+		ft.fetchLk.Lock()
+		defer ft.fetchLk.Unlock()
+
+		var lockfail bool
+		var unlocker io.Closer
+		for {
+			unlocker, err = fslock.Lock(GetVectorDir(), lockFile)
+			if err == nil {
+				break
+			}
+
+			lockfail = true
+
+			le := fslock.LockedError("")
+			if xerrors.As(err, &le) {
+				log.Warnf("acquiring filesystem fetch lock: %s; will retry in %s", err, lockRetry)
+				time.Sleep(lockRetry)
+				continue
+			}
+			ft.errs = append(ft.errs, xerrors.Errorf("acquiring filesystem fetch lock: %w", err))
+			return
+		}
+		defer func() {
+			err := unlocker.Close()
+			if err != nil {
+				log.Errorw("unlock fs lock", "error", err)
+			}
+		}()
+		if lockfail {
+			// we've managed to get the lock, but we need to re-check file contents - maybe it's fetched now
+			ft.fetchAsync(ctx, name, info)
+			return
+		}
+
+		if err := doFetch(ctx, path, info); err != nil {
+			ft.errs = append(ft.errs, xerrors.Errorf("fetching file %s failed: %w", path, err))
+			return
+		}
+		ft.checkFile(path, info)
+		if err != nil {
+			ft.errs = append(ft.errs, xerrors.Errorf("checking file %s failed: %w", path, err))
+			err := os.Remove(path)
+			if err != nil {
+				ft.errs = append(ft.errs, xerrors.Errorf("remove file %s failed: %w", path, err))
+			}
+		}
+	}()
+}
+
+func (ft *fetch) wait(ctx context.Context) error {
+	waitChan := make(chan struct{}, 1)
+
+	go func() {
+		defer close(waitChan)
+		ft.wg.Wait()
+	}()
+
+	select {
+	case <-ctx.Done():
+		log.Infof("context closed... shutting down")
+	case <-waitChan:
+		log.Infof("parameter and key-fetching complete")
+	}
+
+	return multierr.Combine(ft.errs...)
+}
+
+func (ft *fetch) checkFile(path string, info VectorFile) error {
+	checkedLk.Lock()
+	_, ok := checked[path]
+	checkedLk.Unlock()
+	if ok {
+		return nil
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+
+	sum := h.Sum(nil)
+	strSum := hex.EncodeToString(sum[:])
+	if strSum == info.Digest {
+		log.Infof("vector file %s is ok", path)
+
+		checkedLk.Lock()
+		checked[path] = struct{}{}
+		checkedLk.Unlock()
+
+		return nil
+	}
+
+	return xerrors.Errorf("checksum mismatch in param file %s, %s != %s", path, strSum, info.Digest)
+}
+
+func doFetch(ctx context.Context, out string, info VectorFile) error {
+	gw := os.Getenv("IPFS_GATEWAY")
+	if gw == "" {
+		gw = gateway
+	}
+	log.Infof("Fetching %s from %s", out, gw)
+
+	outf, err := os.OpenFile(out, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	if err != nil {
+		return err
+	}
+	defer outf.Close()
+
+	fStat, err := outf.Stat()
+	if err != nil {
+		return err
+	}
+	header := http.Header{}
+	header.Set("Range", "bytes="+strconv.FormatInt(fStat.Size(), 10)+"-")
+	url, err := url.Parse(gw + info.Cid)
+	if err != nil {
+		return err
+	}
+	log.Infof("GET %s", url)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url.String(), nil)
+	if err != nil {
+		return err
+	}
+	req.Close = true
+	req.Header = header
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	bar := pb.New64(fStat.Size() + resp.ContentLength)
+	bar.Set64(fStat.Size())
+	bar.Units = pb.U_BYTES
+	bar.ShowSpeed = true
+	bar.Start()
+
+	_, err = io.Copy(outf, bar.NewProxyReader(resp.Body))
+
+	bar.Finish()
+
+	return err
+}

--- a/itests/fetch/fetch.go
+++ b/itests/fetch/fetch.go
@@ -156,7 +156,7 @@ func (ft *fetch) wait(ctx context.Context) error {
 	case <-ctx.Done():
 		log.Infof("context closed... shutting down")
 	case <-waitChan:
-		log.Infof("parameter and key-fetching complete")
+		log.Infof("test vector fetching complete")
 	}
 
 	return multierr.Combine(ft.errs...)
@@ -193,7 +193,7 @@ func (ft *fetch) checkFile(path string, info VectorFile) error {
 		return nil
 	}
 
-	return xerrors.Errorf("checksum mismatch in param file %s, %s != %s", path, strSum, info.Digest)
+	return xerrors.Errorf("checksum mismatch in test vector file %s, %s != %s", path, strSum, info.Digest)
 }
 
 func doFetch(ctx context.Context, out string, info VectorFile) error {

--- a/itests/init.go
+++ b/itests/init.go
@@ -1,0 +1,83 @@
+package itests
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/filecoin-project/lily/build"
+	"github.com/filecoin-project/lily/itests/fetch"
+	logging "github.com/ipfs/go-log/v2"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+var log = logging.Logger("lily/itests")
+
+const (
+	Calibnet = "calibnet"
+	Mainnet  = "mainnet"
+)
+
+type TestVector struct {
+	From, To int64
+	File     *os.File
+}
+
+var CalibnetTestVectors []*TestVector
+var MainnetTestVectors []*TestVector
+
+func init() {
+	// Attempt to download all test vectors in parallel in 3 mins
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*3)
+	defer cancel()
+	if err := fetch.GetVectors(ctx, build.VectorsJSON()); err != nil {
+		log.Fatalf("fetching test vectors: %v", err)
+	}
+
+	// build lists of test vectors corresponding to networks; to be used in tests
+	var testVectors map[string]fetch.VectorFile
+	if err := json.Unmarshal(build.VectorsJSON(), &testVectors); err != nil {
+		log.Fatal(err)
+	}
+
+	calibVectorCount, mainVectorCount := 0, 0
+	for filename, meta := range testVectors {
+		switch meta.Network {
+		case Calibnet:
+			metaVector, err := vectorsForNetwork(filename, meta)
+			if err != nil {
+				log.Fatal(err)
+			}
+			CalibnetTestVectors = append(CalibnetTestVectors, metaVector)
+			calibVectorCount++
+		case Mainnet:
+			metaVector, err := vectorsForNetwork(filename, meta)
+			if err != nil {
+				log.Fatal(err)
+			}
+			MainnetTestVectors = append(MainnetTestVectors, metaVector)
+			mainVectorCount++
+		}
+	}
+	// this check ensures all the vectors in fetch.VectorFile were downloaded and will be run in the testing suite.
+	if len(MainnetTestVectors) != mainVectorCount {
+		log.Fatal("Failed to download all expected test vectors for mainnet")
+	}
+	if len(CalibnetTestVectors) != calibVectorCount {
+		log.Fatal("Failed to download all expected test vectors for calibnet")
+	}
+}
+
+func vectorsForNetwork(fileName string, meta fetch.VectorFile) (*TestVector, error) {
+	ntwkDir := filepath.Join(fetch.GetVectorDir(), meta.Network)
+
+	f, err := os.Open(filepath.Join(ntwkDir, fileName))
+	if err != nil {
+		return nil, err
+	}
+	return &TestVector{
+		From: meta.From,
+		To:   meta.To,
+		File: f,
+	}, nil
+}

--- a/itests/node.go
+++ b/itests/node.go
@@ -1,0 +1,96 @@
+package itests
+
+import (
+	"context"
+	"github.com/filecoin-project/lily/commands"
+	"github.com/filecoin-project/lily/commands/util"
+	"github.com/filecoin-project/lily/config"
+	"github.com/filecoin-project/lily/lens/lily"
+	"github.com/filecoin-project/lily/lens/lily/modules"
+	lutil "github.com/filecoin-project/lily/lens/util"
+	"github.com/filecoin-project/lily/schedule"
+	"github.com/filecoin-project/lily/storage"
+	lotusbuild "github.com/filecoin-project/lotus/build"
+	"github.com/filecoin-project/lotus/chain/events"
+	"github.com/filecoin-project/lotus/chain/stmgr"
+	"github.com/filecoin-project/lotus/lib/peermgr"
+	"github.com/filecoin-project/lotus/node"
+	lotusmodules "github.com/filecoin-project/lotus/node/modules"
+	"github.com/filecoin-project/lotus/node/modules/dtypes"
+	"github.com/filecoin-project/lotus/node/repo"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+	"io/fs"
+	"testing"
+)
+
+type TestNodeConfig struct {
+	LilyConfig  *config.Conf
+	CacheConfig *lutil.CacheConfig
+	RepoPath    string
+	Snapshot    fs.File
+	ApiEndpoint string
+}
+
+func NewTestNode(t testing.TB, ctx context.Context, cfg *TestNodeConfig) (lily.LilyAPI, node.StopFunc) {
+	r, err := repo.NewFS(cfg.RepoPath)
+	require.NoError(t, err)
+
+	err = r.Init(repo.FullNode)
+	require.NoError(t, err)
+
+	err = util.ImportFromFsFile(ctx, r, cfg.Snapshot, true)
+	require.NoError(t, err)
+
+	genBytes := lotusbuild.MaybeGenesis()
+
+	genesis := node.Options()
+	if len(genBytes) > 0 {
+		genesis = node.Override(new(lotusmodules.Genesis), lotusmodules.LoadGenesis(genBytes))
+	}
+	liteModeDeps := node.Options()
+	shutdown := make(chan struct{})
+	var api lily.LilyAPI
+	stop, err := node.New(ctx,
+		// Start Sentinel Dep injection
+		commands.LilyNodeAPIOption(&api),
+		node.Override(new(*config.Conf), func() (*config.Conf, error) {
+			return cfg.LilyConfig, nil
+		}),
+		node.Override(new(*lutil.CacheConfig), func() (*lutil.CacheConfig, error) {
+			return cfg.CacheConfig, nil
+		}),
+		node.Override(new(*events.Events), modules.NewEvents),
+		node.Override(new(*schedule.Scheduler), schedule.NewSchedulerDaemon),
+		node.Override(new(*storage.Catalog), modules.NewStorageCatalog),
+		// End Injection
+
+		node.Override(new(dtypes.Bootstrapper), false),
+		node.Override(new(dtypes.ShutdownChan), shutdown),
+		node.Base(),
+		node.Repo(r),
+
+		node.Override(new(dtypes.UniversalBlockstore), modules.NewCachingUniversalBlockstore),
+
+		// Inject a custom StateManager, must be done after the node.Online() call as we are
+		// overriding the OG lotus StateManager.
+		node.Override(new(*stmgr.StateManager), modules.StateManager),
+		node.Override(new(stmgr.ExecMonitor), modules.NewBufferedExecMonitor),
+		// End custom StateManager injection.
+		genesis,
+		liteModeDeps,
+		// run the node in offline mode
+		node.Unset(node.RunPeerMgrKey),
+		node.Unset(new(*peermgr.PeerMgr)),
+
+		node.Override(node.SetApiEndpointKey, func(lr repo.LockedRepo) error {
+			apima, err := multiaddr.NewMultiaddr(cfg.ApiEndpoint)
+			if err != nil {
+				return err
+			}
+			return lr.SetAPIEndpoint(apima)
+		}),
+	)
+	require.NoError(t, err)
+	return api, stop
+}

--- a/itests/node.go
+++ b/itests/node.go
@@ -10,7 +10,6 @@ import (
 	lutil "github.com/filecoin-project/lily/lens/util"
 	"github.com/filecoin-project/lily/schedule"
 	"github.com/filecoin-project/lily/storage"
-	lotusbuild "github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/events"
 	"github.com/filecoin-project/lotus/chain/stmgr"
 	"github.com/filecoin-project/lotus/lib/peermgr"
@@ -21,6 +20,7 @@ import (
 	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
 	"io/fs"
+	"io/ioutil"
 	"testing"
 )
 
@@ -29,6 +29,7 @@ type TestNodeConfig struct {
 	CacheConfig *lutil.CacheConfig
 	RepoPath    string
 	Snapshot    fs.File
+	Genesis     fs.File
 	ApiEndpoint string
 }
 
@@ -42,7 +43,8 @@ func NewTestNode(t testing.TB, ctx context.Context, cfg *TestNodeConfig) (lily.L
 	err = util.ImportFromFsFile(ctx, r, cfg.Snapshot, true)
 	require.NoError(t, err)
 
-	genBytes := lotusbuild.MaybeGenesis()
+	genBytes, err := ioutil.ReadAll(cfg.Genesis)
+	require.NoError(t, err)
 
 	genesis := node.Options()
 	if len(genBytes) > 0 {

--- a/itests/validators.go
+++ b/itests/validators.go
@@ -1,0 +1,266 @@
+package itests
+
+import (
+	"context"
+	"fmt"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/lily/chain"
+	"github.com/filecoin-project/lily/lens/lily"
+	"github.com/filecoin-project/lily/model/actors/common"
+	"github.com/filecoin-project/lily/model/blocks"
+	chain2 "github.com/filecoin-project/lily/model/chain"
+	"github.com/filecoin-project/lily/model/messages"
+	"github.com/filecoin-project/lily/storage"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/go-pg/pg/v10"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var TaskModels = map[string][]string{
+	chain.MessagesTask:       {"messages", "parsed_messages", "block_messages", "derived_gas_outputs", "message_gas_economy", "receipts"},
+	chain.BlocksTask:         {"block_headers", "block_parents", "drand_block_entries"},
+	chain.ChainConsensusTask: {"chain_consensus"},
+	chain.ActorStatesRawTask: {"actors", "actor_states"},
+}
+
+var TaskValidators = map[string][]interface{}{
+	chain.MessagesTask:       {BlockMessagesValidator{}, ReceiptsValidator{}},
+	chain.BlocksTask:         {BlockHeaderValidator{}, BlockParentsValidator{}, DrandBlockEntriesValidator{}},
+	chain.ChainConsensusTask: {ChainConsensusValidator{}},
+	chain.ActorStatesRawTask: {ActorValidator{}, ActorStatesValidator{}},
+}
+
+type TipSetStateValidator interface {
+	Validate(t *testing.T, state *TipSetState, strg *storage.Database)
+}
+
+type EpochValidator interface {
+	Validate(t *testing.T, epoch int64, ts *types.TipSet, strg *storage.Database, api *lily.LilyNodeAPI)
+}
+
+var _ EpochValidator = (*ChainConsensusValidator)(nil)
+
+type ChainConsensusValidator struct{}
+
+func (ChainConsensusValidator) Validate(t *testing.T, epoch int64, ts *types.TipSet, strg *storage.Database, api *lily.LilyNodeAPI) {
+	t.Run(fmt.Sprintf("chain_consensus_%d", epoch), func(t *testing.T) {
+		ctx := context.Background()
+		var m *chain2.ChainConsensus
+
+		// Null round
+		if ts == nil {
+			// expect the parenttipset state at this epoch to be the last null round tipset and the tipset for the null
+			// round to be null
+			pts, err := api.ChainGetTipSetByHeight(ctx, abi.ChainEpoch(epoch), types.EmptyTSK)
+			require.NoError(t, err)
+
+			exists, err := strg.AsORM().Model(m).
+				Where("height = ?", epoch).
+				Where("parent_state_root = ?", pts.ParentState().String()).
+				Where("parent_tip_set = ?", pts.Parents().String()).
+				Where("tip_set is null").
+				Exists()
+			require.NoError(t, err)
+			assert.True(t, exists, "expected model with height %d, state_root %s", epoch, pts.ParentState())
+		} else {
+			exists, err := strg.AsORM().Model(m).
+				Where("height = ?", epoch).
+				Where("parent_state_root = ?", ts.ParentState().String()).
+				Where("parent_tip_set = ?", ts.Parents().String()).
+				Where("tip_set = ?", ts.Key().String()).
+				Exists()
+			require.NoError(t, err)
+			assert.True(t, exists, "expected model with height %d, state_root %s", ts.Height(), ts.ParentState())
+
+		}
+		var count int
+		_, err := strg.AsORM().QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM chain_consensus WHERE height = ?`, epoch)
+		require.NoError(t, err)
+		assert.EqualValues(t, 1, count)
+	})
+}
+
+var _ TipSetStateValidator = (*DrandBlockEntriesValidator)(nil)
+
+type DrandBlockEntriesValidator struct{}
+
+func (DrandBlockEntriesValidator) Validate(t *testing.T, state *TipSetState, strg *storage.Database) {
+	t.Run(fmt.Sprintf("drand_block_entries_%d", state.ts.Height()), func(t *testing.T) {
+		for _, bh := range state.ts.Blocks() {
+			for _, round := range bh.BeaconEntries {
+				var m *blocks.DrandBlockEntrie
+				exists, err := strg.AsORM().Model(m).
+					Where("block = ?", bh.Cid().String()).
+					Where("round = ?", round.Round).
+					Exists()
+				require.NoError(t, err)
+				assert.True(t, exists, "expected model with cid: %s round: %d", bh.Cid(), round.Round)
+
+				var count int
+				_, err = strg.AsORM().QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM drand_block_entries WHERE block = ?`, bh.Cid().String())
+				require.NoError(t, err)
+				assert.Equal(t, len(bh.BeaconEntries), count)
+			}
+
+		}
+	})
+}
+
+var _ TipSetStateValidator = (*ActorValidator)(nil)
+
+type ActorValidator struct{}
+
+func (ActorValidator) Validate(t *testing.T, state *TipSetState, strg *storage.Database) {
+	t.Run(fmt.Sprintf("actor_%d", state.ts.Height()), func(t *testing.T) {
+		for addr, act := range state.actorsChanges {
+			var m *common.Actor
+			exists, err := strg.AsORM().Model(m).
+				Where("height = ?", state.ts.Height()).
+				Where("state_root = ?", state.ts.ParentState().String()).
+				Where("head = ?", act.Head.String()).
+				Where("nonce = ?", act.Nonce).
+				Where("balance = ?", act.Balance.String()).
+				Where("id = ?", addr.String()).
+				Exists()
+			require.NoError(t, err)
+			assert.Truef(t, exists, "expected model with height %d, state_root %s, head %s, address %s", state.ts.Height(), state.ts.ParentState(), act.Head, addr)
+		}
+
+		// the total number of actor models at this height should be equal to the number of actors in TipSetState.
+		var count int
+		_, err := strg.AsORM().QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM actors WHERE height = ?`, state.ts.Height())
+		require.NoError(t, err)
+		assert.Equal(t, len(state.actorsChanges), count)
+	})
+}
+
+var _ TipSetStateValidator = (*ActorStatesValidator)(nil)
+
+type ActorStatesValidator struct{}
+
+func (ActorStatesValidator) Validate(t *testing.T, state *TipSetState, strg *storage.Database) {
+	t.Run(fmt.Sprintf("actor_states_%d", state.ts.Height()), func(t *testing.T) {
+		for _, act := range state.actorsChanges {
+			var m *common.ActorState
+			exists, err := strg.AsORM().Model(m).
+				Where("height = ?", state.ts.Height()).
+				Where("head = ?", act.Head.String()).
+				Where("code = ?", act.Code.String()).
+				Exists()
+			require.NoError(t, err)
+			assert.Truef(t, exists, "expected model with height %d, head %s, code %s", state.ts.Height(), act.Head, act.Code)
+		}
+
+		var count int
+		_, err := strg.AsORM().QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM actor_states WHERE height = ?`, state.ts.Height())
+		require.NoError(t, err)
+		assert.Equal(t, len(state.actorsChanges), count)
+	})
+}
+
+var _ TipSetStateValidator = (*BlockHeaderValidator)(nil)
+
+type BlockHeaderValidator struct{}
+
+func (BlockHeaderValidator) Validate(t *testing.T, state *TipSetState, strg *storage.Database) {
+	t.Run(fmt.Sprintf("block_headers_%d", state.ts.Height()), func(t *testing.T) {
+		for _, bh := range state.ts.Blocks() {
+			var m *blocks.BlockHeader
+			exists, err := strg.AsORM().Model(m).
+				Where("cid = ?", bh.Cid().String()).
+				Where("height = ?", int64(bh.Height)).
+				Exists()
+			require.NoError(t, err)
+			assert.True(t, exists, "expected model with cid: %s height: %d", bh.Cid(), bh.Height)
+		}
+
+		var count int
+		_, err := strg.AsORM().QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM block_headers WHERE height = ?`, state.ts.Height())
+		require.NoError(t, err)
+		assert.Equal(t, len(state.ts.Blocks()), count)
+	})
+}
+
+var _ TipSetStateValidator = (*BlockMessagesValidator)(nil)
+
+type BlockMessagesValidator struct{}
+
+func (BlockMessagesValidator) Validate(t *testing.T, state *TipSetState, strg *storage.Database) {
+	t.Run(fmt.Sprintf("block_messages_%d", state.ts.Height()), func(t *testing.T) {
+		var msgCount int
+		for blk, msgs := range state.blockMsgs {
+			msgCount += len(msgs.Cids)
+			for _, msg := range msgs.Cids {
+				var m *messages.BlockMessage
+				exists, err := strg.AsORM().Model(m).
+					Where("height = ?", blk.Height).
+					Where("block = ?", blk.Cid().String()).
+					Where("message = ?", msg.String()).
+					Exists()
+				require.NoError(t, err)
+				assert.Truef(t, exists, "expected model with height %d, block %s, messages %s", blk.Height, blk.Cid(), msg)
+			}
+		}
+
+		var count int
+		_, err := strg.AsORM().QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM block_messages WHERE height = ?`, state.ts.Height())
+		require.NoError(t, err)
+		assert.Equal(t, msgCount, count, "expect model with height = %d", state.ts.Height())
+	})
+}
+
+var _ TipSetStateValidator = (*BlockParentsValidator)(nil)
+
+type BlockParentsValidator struct{}
+
+func (BlockParentsValidator) Validate(t *testing.T, state *TipSetState, strg *storage.Database) {
+	t.Run(fmt.Sprintf("block_parents_%d", state.ts.Height()), func(t *testing.T) {
+		totalBlockParents := 0
+		for _, blk := range state.blocks {
+			for _, parent := range blk.Parents {
+				totalBlockParents++
+				var m *blocks.BlockParent
+				exists, err := strg.AsORM().Model(m).
+					Where("height = ?", blk.Height).
+					Where("block = ?", blk.Cid().String()).
+					Where("parent = ?", parent.String()).
+					Exists()
+				require.NoError(t, err)
+				assert.Truef(t, exists, "expected model with height %d, block %s, parent %s", blk.Height, blk.Cid(), parent)
+			}
+		}
+
+		var count int
+		_, err := strg.AsORM().QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM block_parents WHERE height = ?`, state.ts.Height())
+		require.NoError(t, err)
+		assert.Equal(t, totalBlockParents, count, "expect model with height = ?", state.ts.Height())
+	})
+}
+
+var _ TipSetStateValidator = (*ReceiptsValidator)(nil)
+
+type ReceiptsValidator struct{}
+
+func (ReceiptsValidator) Validate(t *testing.T, state *TipSetState, strg *storage.Database) {
+	t.Run(fmt.Sprintf("receipts_%d", state.ts.Height()), func(t *testing.T) {
+		for msg, rect := range state.msgRects {
+			var m *messages.Receipt
+			exists, err := strg.AsORM().Model(m).
+				Where("height = ?", state.ts.Height()).
+				Where("message = ?", msg.String()).
+				Where("state_root = ?", state.ts.ParentState().String()).
+				Where("exit_code = ?", rect.ExitCode).
+				Where("gas_used = ?", rect.GasUsed).
+				Exists()
+			require.NoError(t, err)
+			assert.True(t, exists, "expected model with height %d, message %s", state.ts.Height(), msg.String())
+		}
+
+		var count int
+		_, err := strg.AsORM().QueryOne(pg.Scan(&count), `SELECT COUNT(*) FROM receipts WHERE height = ?`, state.ts.Height())
+		require.NoError(t, err)
+		assert.Equal(t, len(state.msgRects), count)
+	})
+}

--- a/itests/vector_test.go
+++ b/itests/vector_test.go
@@ -1,6 +1,3 @@
-//go:build calibnet
-// +build calibnet
-
 package itests
 
 import (
@@ -28,7 +25,7 @@ func TestCalibrationVector(t *testing.T) {
 
 	for _, vf := range CalibnetTestVectors {
 		t.Run(filepath.Base(vf.File.Name()), func(t *testing.T) {
-			tvb := NewVectorWalkValidatorBuilder(vf.File).
+			tvb := NewVectorWalkValidatorBuilder(vf).
 				WithDatabase(strg).
 				WithRange(vf.From, vf.To-1). // TODO file bug
 				WithTasks(chain.ActorStatesRawTask, chain.BlocksTask, chain.MessagesTask, chain.ChainConsensusTask)
@@ -37,6 +34,7 @@ func TestCalibrationVector(t *testing.T) {
 			stop := vw.Run(ctx)
 			vw.Validate(t)
 			require.NoError(t, stop(ctx))
+			require.NoError(t, vf.Close())
 		})
 	}
 }

--- a/itests/vector_test.go
+++ b/itests/vector_test.go
@@ -17,7 +17,7 @@ import (
 func TestCalibrationVector(t *testing.T) {
 	logging.SetAllLoggers(logging.LevelInfo)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*10)
 	defer cancel()
 
 	strg, strgCleanup := tstorage.WaitForExclusiveMigratedStorage(ctx, t, false)

--- a/itests/vector_test.go
+++ b/itests/vector_test.go
@@ -1,0 +1,42 @@
+//go:build calibnet
+// +build calibnet
+
+package itests
+
+import (
+	"context"
+	"github.com/filecoin-project/lily/chain"
+	tstorage "github.com/filecoin-project/lily/storage/testing"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/stretchr/testify/require"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCalibrationVector(t *testing.T) {
+	logging.SetAllLoggers(logging.LevelInfo)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+	defer cancel()
+
+	strg, strgCleanup := tstorage.WaitForExclusiveMigratedStorage(ctx, t, false)
+	t.Cleanup(func() {
+		err := strgCleanup()
+		require.NoError(t, err)
+	})
+
+	for _, vf := range CalibnetTestVectors {
+		t.Run(filepath.Base(vf.File.Name()), func(t *testing.T) {
+			tvb := NewVectorWalkValidatorBuilder(vf.File).
+				WithDatabase(strg).
+				WithRange(vf.From, vf.To-1). // TODO file bug
+				WithTasks(chain.ActorStatesRawTask, chain.BlocksTask, chain.MessagesTask, chain.ChainConsensusTask)
+
+			vw := tvb.Build(ctx, t)
+			stop := vw.Run(ctx)
+			vw.Validate(t)
+			require.NoError(t, stop(ctx))
+		})
+	}
+}

--- a/storage/testing/storage.go
+++ b/storage/testing/storage.go
@@ -1,0 +1,67 @@
+package testing
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/go-pg/pg/v10"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/lily/storage"
+	"github.com/filecoin-project/lily/testutil"
+)
+
+var testDatabase = os.Getenv("LILY_TEST_DB")
+
+func WaitForExclusiveMigratedStorage(ctx context.Context, tb testing.TB, debugLogs bool) (*storage.Database, func() error) {
+	db, err := storage.NewDatabase(ctx, testDatabase, 10, tb.Name(), "public", false)
+	require.NoError(tb, err)
+
+	dbVersion, latest, err := db.GetSchemaVersions(ctx)
+	require.NoError(tb, err)
+	if dbVersion != latest {
+		err = db.MigrateSchema(ctx)
+		require.NoError(tb, err)
+	}
+
+	err = db.Connect(ctx)
+	require.NoError(tb, err)
+
+	release, err := testutil.WaitForExclusiveDatabaseLock(ctx, db.AsORM())
+	if err != nil {
+		db.Close(ctx) // nolint: errcheck
+		tb.Fatalf("failed to get exclusive database access: %v", err)
+	}
+
+	cleanup := func() error {
+		_ = release()
+		return db.Close(ctx) // nolint: errcheck
+	}
+
+	if debugLogs {
+		db.AsORM().AddQueryHook(&LoggingQueryHook{})
+	}
+	return db, cleanup
+}
+
+type LoggingQueryHook struct{}
+
+func (l *LoggingQueryHook) BeforeQuery(ctx context.Context, event *pg.QueryEvent) (context.Context, error) {
+	q, err := event.FormattedQuery()
+	if err != nil {
+		return nil, err
+	}
+
+	if event.Err != nil {
+		fmt.Printf("%s executing a query:\n%s\n", event.Err, q)
+	}
+	fmt.Println(string(q))
+
+	return ctx, nil
+}
+
+func (l *LoggingQueryHook) AfterQuery(ctx context.Context, event *pg.QueryEvent) error {
+	return nil
+}


### PR DESCRIPTION
### What
Revive vector tests - this PR adds the logic for testing lily via test vectors!
#### Add new vectors:
Add a vector to `build/test-vectors/vectors.json`, see `build/test-vectors/README.md` for instruction on how to do this

#### Execute vectors
Right now we only have vectors from the calibration network. Mainnet vectors can be added later with no modification to the test suite. 
When executing `make itest-calibration` for the follow occurs:
1. Vectors are downloaded (based on`vector.json`) to `/var/tmp/lily-test-vectors/<network_name>`. If the vector files are cached their contents is simply validated.
2. Ensure the expected vectors are present on the filesystem, failing the test suite otherwise.
3. Connect to timescale instance, migrating to the latest version if required.
4. Construct a full in-memory lily node, configured to talk to storage from the previous step
5. Execute a walk over each vector, the range of the walk is configured via the `to` and `from` fields in `vectors.json`.
6. Extract state from the vector using lotus api methods.
7. Compare data returned by lotus API with contents of storage, passing if equivalent, failing otherwise.

#### How do I run this?
`make dockerup && make itest-calibnet`