### PR TITLE
fix(docker): Make dirty docker builds clean

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,0 @@
-/.circleci
-/.github
-/build/*
-/extern/filecoin-ffi
-/Dockerfile*
-/docker-compose*
-/sentinel-visor

--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,7 @@
 *.out
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
 .idea
-visor
 !model/visor
 /*lily
 


### PR DESCRIPTION
Lily has items committed to the repo which are also listed in `.dockerignore`. When docker sends the context during build, it is missing files which git state interprets as "dirty".

Removing `.dockerignore` fixes this problem. There are also some `.gitignore` cleanup.