### PR TITLE
fix(docker): Docker image build versions are no longer "dirty"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,13 +42,13 @@ commands:
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
-            LILY_IMAGE_TAG=${CIRCLE_BRANCH//\//-}-${tag_suffix} make docker-mainnet-push
+            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_BRANCH//\//-}-${tag_suffix} make docker-mainnet-push
       - run:
           name: Publish Calibnet Production Docker Image to Docker Hub
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
-            LILY_IMAGE_TAG=${CIRCLE_BRANCH//\//-}-${tag_suffix}-calibnet make docker-calibnet-push
+            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_BRANCH//\//-}-${tag_suffix}-calibnet make docker-calibnet-push
   publish-docker-from-branch-dev:
     steps:
       - run:
@@ -56,32 +56,32 @@ commands:
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
-            LILY_IMAGE_TAG=${CIRCLE_BRANCH//\//-}-${tag_suffix}-dev make docker-mainnet-dev-push
+            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_BRANCH//\//-}-${tag_suffix}-dev make docker-mainnet-dev-push
       - run:
           name: Publish Calibnet Dev Docker Image to Docker Hub
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
-            LILY_IMAGE_TAG=${CIRCLE_BRANCH//\//-}-${tag_suffix}-calibnet-dev make docker-calibnet-dev-push
+            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_BRANCH//\//-}-${tag_suffix}-calibnet-dev make docker-calibnet-dev-push
   publish-docker-semver-production:
     steps:
       - run:
           name: Publish Mainnet Production Semver Docker Image to Docker Hub
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            LILY_IMAGE_TAG=${CIRCLE_TAG//\//-} make docker-mainnet-push
+            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_TAG//\//-} make docker-mainnet-push
             # omit release candidates from pushing latest
             if [[ ! "$CIRCLE_TAG" =~ -rc[0-9]+$ ]]; then
-              LILY_IMAGE_TAG=latest make docker-mainnet-push
+              LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=latest make docker-mainnet-push
             fi
       - run:
           name: Publish Calibnet Production Semver Docker Image to Docker Hub
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            LILY_IMAGE_TAG=${CIRCLE_TAG//\//-}-calibnet make docker-calibnet-push
+            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_TAG//\//-}-calibnet make docker-calibnet-push
             # omit release candidates from pushing calibnet-latest
             if [[ ! "$CIRCLE_TAG" =~ -rc[0-9]+$ ]]; then
-              LILY_IMAGE_TAG=calibnet-latest make docker-calibnet-push
+              LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=calibnet-latest make docker-calibnet-push
             fi
   publish-docker-semver-dev:
     steps:
@@ -89,12 +89,12 @@ commands:
           name: Publish Mainnet Dev Semver Docker Image to Docker Hub
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            LILY_IMAGE_TAG=${CIRCLE_TAG//\//-}-dev make docker-mainnet-dev-push
+            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_TAG//\//-}-dev make docker-mainnet-dev-push
       - run:
           name: Publish Calibnet Dev Semver Docker Image to Docker Hub
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            LILY_IMAGE_TAG=${CIRCLE_TAG//\//-}-calibnet-dev make docker-calibnet-dev-push
+            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_TAG//\//-}-calibnet-dev make docker-calibnet-dev-push
 
 jobs:
   publish-docker-from-master:

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,12 @@
+/.codecov.yml
+/.gitignore
 /.circleci
 /.github
+/*.md
 /build/*
 /extern/filecoin-ffi
+/extern/fil-blst
 /Dockerfile*
 /docker-compose*
-/sentinel-visor
+/itests/*
+/scripts/*

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ GO_BUILD_IMAGE?=golang:1.17.6
 PG_IMAGE?=postgres:10
 REDIS_IMAGE?=redis:6
 LILY_IMAGE_NAME?=filecoin/lily
-COMMIT := $(shell git rev-parse --short=8 HEAD)
 
-# GITVERSION is the nearest tag plus number of commits and short form of most recent commit since the tag, if any
-GITVERSION=$(shell git describe --always --tag --dirty)
+# LILY_VERSION is the nearest tag plus number of commits and short form of
+# most recent commit since the tag, if any. It may be overriden by the environment.
+LILY_VERSION?=$(shell git describe --always --tag --dirty)
 
 unexport GOFLAGS
 
@@ -53,7 +53,7 @@ CLEAN+=build/.update-modules
 # tools
 toolspath:=support/tools
 
-ldflags=-X=github.com/filecoin-project/lily/version.GitVersion=$(GITVERSION)
+ldflags=-X=github.com/filecoin-project/lily/version.GitVersion=$(LILY_VERSION)
 ifneq ($(strip $(LDFLAGS)),)
 	ldflags+=-extldflags=$(LDFLAGS)
 endif
@@ -176,7 +176,7 @@ CLEAN+=Dockerfile.dev
 .PHONY: docker-mainnet
 docker-mainnet: LILY_DOCKER_FILE ?= Dockerfile
 docker-mainnet: LILY_NETWORK_TARGET ?= mainnet
-docker-mainnet: LILY_IMAGE_TAG ?= $(COMMIT)
+docker-mainnet: LILY_IMAGE_TAG ?= $(LILY_VERSION)
 docker-mainnet: docker-build-image-template
 
 .PHONY: docker-mainnet-push
@@ -185,7 +185,7 @@ docker-mainnet-push: docker-mainnet docker-tag-and-push-template
 .PHONY: docker-mainnet-dev
 docker-mainnet-dev: LILY_DOCKER_FILE ?= Dockerfile.dev
 docker-mainnet-dev: LILY_NETWORK_TARGET ?= mainnet
-docker-mainnet-dev: LILY_IMAGE_TAG ?= $(COMMIT)-dev
+docker-mainnet-dev: LILY_IMAGE_TAG ?= $(LILY_VERSION)-dev
 docker-mainnet-dev: docker-build-image-template
 
 .PHONY: docker-mainnet-dev-push
@@ -195,7 +195,7 @@ docker-mainnet-dev-push: docker-mainnet-dev docker-tag-and-push-template
 .PHONY: docker-calibnet
 docker-calibnet: LILY_DOCKER_FILE ?= Dockerfile
 docker-calibnet: LILY_NETWORK_TARGET ?= calibnet
-docker-calibnet: LILY_IMAGE_TAG ?= $(COMMIT)-calibnet
+docker-calibnet: LILY_IMAGE_TAG ?= $(LILY_VERSION)-calibnet
 docker-calibnet: docker-build-image-template
 
 .PHONY: docker-calibnet-push
@@ -204,7 +204,7 @@ docker-calibnet-push: docker-calibnet docker-tag-and-push-template
 .PHONY: docker-calibnet-dev
 docker-calibnet-dev: LILY_DOCKER_FILE ?= Dockerfile.dev
 docker-calibnet-dev: LILY_NETWORK_TARGET ?= calibnet
-docker-calibnet-dev: LILY_IMAGE_TAG ?= $(COMMIT)-calibnet-dev
+docker-calibnet-dev: LILY_IMAGE_TAG ?= $(LILY_VERSION)-calibnet-dev
 docker-calibnet-dev: docker-build-image-template
 
 .PHONY: docker-calibnet-dev-push
@@ -214,7 +214,7 @@ docker-calibnet-dev-push: docker-calibnet-dev docker-tag-and-push-template
 .PHONY: docker-interopnet
 docker-interopnet: LILY_DOCKER_FILE ?= Dockerfile
 docker-interopnet: LILY_NETWORK_TARGET ?= interopnet
-docker-interopnet: LILY_IMAGE_TAG ?= $(COMMIT)-interopnet
+docker-interopnet: LILY_IMAGE_TAG ?= $(LILY_VERSION)-interopnet
 docker-interopnet: docker-build-image-template
 
 .PHONY: docker-interopnet-push
@@ -223,7 +223,7 @@ docker-interopnet-push: docker-interopnet docker-tag-and-push-template
 .PHONY: docker-interopnet-dev
 docker-interopnet-dev: LILY_DOCKER_FILE ?= Dockerfile.dev
 docker-interopnet-dev: LILY_NETWORK_TARGET ?= interopnet
-docker-interopnet-dev: LILY_IMAGE_TAG ?= $(COMMIT)-interopnet-dev
+docker-interopnet-dev: LILY_IMAGE_TAG ?= $(LILY_VERSION)-interopnet-dev
 docker-interopnet-dev: docker-build-image-template
 
 .PHONY: docker-interopnet-dev-push
@@ -233,7 +233,7 @@ docker-interopnet-dev-push: docker-interopnet-dev docker-tag-and-push-template
 .PHONY: docker-butterflynet
 docker-butterflynet: LILY_DOCKER_FILE ?= Dockerfile
 docker-butterflynet: LILY_NETWORK_TARGET ?= butterflynet
-docker-butterflynet: LILY_IMAGE_TAG ?= $(COMMIT)-butterflynet
+docker-butterflynet: LILY_IMAGE_TAG ?= $(LILY_VERSION)-butterflynet
 docker-butterflynet: docker-build-image-template
 
 .PHONY: docker-butterflynet-push
@@ -242,7 +242,7 @@ docker-butterflynet-push: docker-butterflynet docker-tag-and-push-template
 .PHONY: docker-butterflynet-dev
 docker-butterflynet-dev: LILY_DOCKER_FILE ?= Dockerfile.dev
 docker-butterflynet-dev: LILY_NETWORK_TARGET ?= butterflynet
-docker-butterflynet-dev: LILY_IMAGE_TAG ?= $(COMMIT)-butterflynet-dev
+docker-butterflynet-dev: LILY_IMAGE_TAG ?= $(LILY_VERSION)-butterflynet-dev
 docker-butterflynet-dev: docker-build-image-template
 
 .PHONY: docker-butterflynet-dev-push
@@ -252,7 +252,7 @@ docker-butterflynet-dev-push: docker-butterflynet-dev docker-tag-and-push-templa
 .PHONY: docker-nerpanet
 docker-nerpanet: LILY_DOCKER_FILE ?= Dockerfile
 docker-nerpanet: LILY_NETWORK_TARGET ?= nerpanet
-docker-nerpanet: LILY_IMAGE_TAG ?= $(COMMIT)-nerpanet
+docker-nerpanet: LILY_IMAGE_TAG ?= $(LILY_VERSION)-nerpanet
 docker-nerpanet: docker-build-image-template
 
 .PHONY: docker-nerpanet-push
@@ -261,7 +261,7 @@ docker-nerpanet-push: docker-nerpanet docker-tag-and-push-template
 .PHONY: docker-nerpanet-dev
 docker-nerpanet-dev: LILY_DOCKER_FILE ?= Dockerfile.dev
 docker-nerpanet-dev: LILY_NETWORK_TARGET ?= nerpanet
-docker-nerpanet-dev: LILY_IMAGE_TAG ?= $(COMMIT)-nerpanet-dev
+docker-nerpanet-dev: LILY_IMAGE_TAG ?= $(LILY_VERSION)-nerpanet-dev
 docker-nerpanet-dev: docker-build-image-template
 
 .PHONY: docker-nerpanet-dev-push
@@ -271,7 +271,7 @@ docker-nerpanet-dev-push: docker-nerpanet-dev docker-tag-and-push-template
 .PHONY: docker-2k
 docker-2k: LILY_DOCKER_FILE ?= Dockerfile
 docker-2k: LILY_NETWORK_TARGET ?= 2k
-docker-2k: LILY_IMAGE_TAG ?= $(COMMIT)-2k
+docker-2k: LILY_IMAGE_TAG ?= $(LILY_VERSION)-2k
 docker-2k: docker-build-image-template
 
 .PHONY: docker-2k-push
@@ -280,17 +280,17 @@ docker-2k-push: docker-2k docker-tag-and-push-template
 .PHONY: docker-2k-dev
 docker-2k-dev: LILY_DOCKER_FILE ?= Dockerfile.dev
 docker-2k-dev: LILY_NETWORK_TARGET ?= 2k
-docker-2k-dev: LILY_IMAGE_TAG ?= $(COMMIT)-2k-dev
+docker-2k-dev: LILY_IMAGE_TAG ?= $(LILY_VERSION)-2k-dev
 docker-2k-dev: docker-build-image-template
 
 .PHONY: docker-2k-dev-push
 docker-2k-dev-push: docker-2k-dev docker-tag-and-push-template
 
-
 .PHONY: docker-build-image-template
-docker-build-image-template:
-	@echo "Building lily docker image for '$(LILY_NETWORK_TARGET)'..."
+docker-build-image-template: clean docker-files
+	@echo "Building $(LILY_IMAGE_NAME):$(LILY_IMAGE_TAG) docker image for $(LILY_NETWORK_TARGET)..."
 	docker build -f $(LILY_DOCKER_FILE) \
+		--build-arg LILY_VERSION=$(LILY_VERSION) \
 		--build-arg LILY_NETWORK_TARGET=$(LILY_NETWORK_TARGET) \
 		--build-arg GO_BUILD_IMAGE=$(GO_BUILD_IMAGE) \
 		-t $(LILY_IMAGE_NAME) \

--- a/build/docker/builder.tpl
+++ b/build/docker/builder.tpl
@@ -3,12 +3,13 @@
 
 # ARG GO_BUILD_IMAGE is the image tag to use when building lily
 ARG GO_BUILD_IMAGE
-FROM $GO_BUILD_IMAGE AS builder
 
 # ARG LILY_NETWORK_TARGET determines which network the lily binary is built for.
 # Options: mainnet, nerpanet, calibnet, butterflynet, interopnet, 2k
 # See https://network.filecoin.io/ for more information about network_targets.
-ARG LILY_NETWORK_TARGET=mainnet
+ARG LILY_NETWORK_TARGET
+
+FROM $GO_BUILD_IMAGE AS builder
 
 RUN apt-get update
 RUN apt-get install -y \
@@ -23,6 +24,11 @@ COPY . /go/src/github.com/filecoin-project/lily
 
 RUN make deps
 RUN go mod download
+
+# ARG LILY_VERSION will set the binary version upon build
+ARG LILY_VERSION
+ENV LILY_VERSION=$LILY_VERSION
+
 RUN make $LILY_NETWORK_TARGET
 RUN cp ./lily /usr/bin/
 


### PR DESCRIPTION
Building the lily binary within the docker context makes the build
version always "dirty". This is because dockerignore omits files
from the build context which are committed into the git repo. When
these files are missing, git considers that repo "dirty".

This change allows the Makefile to use LILY_VERSION to set the build
version of the lily binary. This value used as an envvar within the
docker build environment which overrides the default ("dirty")
LILY_VERSION with the version perceived by git before dockerignore
filters/removes files from the build.