### PR TITLE
setup for indexer refacor

### DIFF
--- a/tasks/actorstate/account.go
+++ b/tasks/actorstate/account.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/filecoin-project/lily/chain/actors/builtin/account"
-	"github.com/filecoin-project/lily/lens"
 	"github.com/filecoin-project/lily/model"
 )
 
@@ -18,7 +17,7 @@ func init() {
 }
 
 // Extract will create persistable data for a given actor's state.
-func (AccountExtractor) Extract(ctx context.Context, a ActorInfo, emsgs []*lens.ExecutedMessage, node ActorStateAPI) (model.Persistable, error) {
+func (AccountExtractor) Extract(ctx context.Context, a ActorInfo, node ActorStateAPI) (model.Persistable, error) {
 	return model.NoData, nil
 }
 

--- a/tasks/actorstate/account_test.go
+++ b/tasks/actorstate/account_test.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/filecoin-project/lily/lens"
 	"github.com/filecoin-project/lily/model"
 )
 
 func TestAccountExtract(t *testing.T) {
 	ae := AccountExtractor{}
-	d, err := ae.Extract(context.Background(), ActorInfo{}, []*lens.ExecutedMessage{}, nil)
+	d, err := ae.Extract(context.Background(), ActorInfo{}, nil)
 	if d != model.NoData {
 		t.Fatal("expected not to extract any extra data")
 	}

--- a/tasks/actorstate/actor.go
+++ b/tasks/actorstate/actor.go
@@ -17,7 +17,7 @@ import (
 // ActorExtractor extracts common actor state
 type ActorExtractor struct{}
 
-func (ActorExtractor) Extract(ctx context.Context, a ActorInfo, emsgs []*lens.ExecutedMessage, node ActorStateAPI) (model.Persistable, error) {
+func (ActorExtractor) Extract(ctx context.Context, a ActorInfo, node ActorStateAPI) (model.Persistable, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "ActorExtractor")
 	defer span.End()
 

--- a/tasks/actorstate/actor_test.go
+++ b/tasks/actorstate/actor_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/filecoin-project/lily/lens"
 	commonmodel "github.com/filecoin-project/lily/model/actors/common"
 	"github.com/filecoin-project/lily/tasks/actorstate"
 )
@@ -49,7 +48,7 @@ func TestActorExtractor(t *testing.T) {
 	}
 
 	ex := actorstate.ActorExtractor{}
-	res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+	res, err := ex.Extract(ctx, info, mapi)
 	assert.NoError(t, err)
 
 	actualState, ok := res.(*commonmodel.ActorTaskResult)

--- a/tasks/actorstate/actorstate.go
+++ b/tasks/actorstate/actorstate.go
@@ -43,11 +43,13 @@ type ActorStateAPI interface {
 	// TODO(remove): StateMinerSectors loads the actor and then calls miner.Load which StorageMinerExtractor already has available
 	// StateMinerSectors(ctx context.Context, addr address.Address, bf *bitfield.BitField, tsk types.TipSetKey) ([]*miner.SectorOnChainInfo, error)
 	Store() adt.Store
+
+	ExecutedAndBlockMessages(ctx context.Context, ts, pts *types.TipSet) (*lens.TipSetMessages, error)
 }
 
 // An ActorStateExtractor extracts actor state into a persistable format
 type ActorStateExtractor interface {
-	Extract(ctx context.Context, a ActorInfo, emsgs []*lens.ExecutedMessage, node ActorStateAPI) (model.Persistable, error)
+	Extract(ctx context.Context, a ActorInfo, node ActorStateAPI) (model.Persistable, error)
 }
 
 // All supported actor state extractors

--- a/tasks/actorstate/actorstate_test.go
+++ b/tasks/actorstate/actorstate_test.go
@@ -35,6 +35,8 @@ import (
 
 	"github.com/filecoin-project/lily/chain/actors/adt"
 	"github.com/filecoin-project/lily/chain/actors/builtin/miner"
+	"github.com/filecoin-project/lily/lens"
+
 	"github.com/filecoin-project/lily/tasks/actorstate"
 	"github.com/filecoin-project/lily/testutil"
 )
@@ -121,6 +123,11 @@ func (m *MockAPI) MinerPower(ctx context.Context, addr address.Address, ts *type
 
 func (m *MockAPI) StateMinerSectors(ctx context.Context, a address.Address, field *bitfield.BitField, key types.TipSetKey) ([]*miner.SectorOnChainInfo, error) {
 	panic("not implemented yet")
+}
+
+func (m *MockAPI) ExecutedAndBlockMessages(ctx context.Context, ts, pts *types.TipSet) (*lens.TipSetMessages, error) {
+	//TODO implement me
+	panic("implement me")
 }
 
 // ----------------- MockAPI Helpers ----------------------------

--- a/tasks/actorstate/init.go
+++ b/tasks/actorstate/init.go
@@ -10,7 +10,6 @@ import (
 	"golang.org/x/xerrors"
 
 	init_ "github.com/filecoin-project/lily/chain/actors/builtin/init"
-	"github.com/filecoin-project/lily/lens"
 	"github.com/filecoin-project/lily/metrics"
 	"github.com/filecoin-project/lily/model"
 	initmodel "github.com/filecoin-project/lily/model/actors/init"
@@ -27,7 +26,7 @@ func init() {
 	}
 }
 
-func (InitExtractor) Extract(ctx context.Context, a ActorInfo, emsgs []*lens.ExecutedMessage, node ActorStateAPI) (model.Persistable, error) {
+func (InitExtractor) Extract(ctx context.Context, a ActorInfo, node ActorStateAPI) (model.Persistable, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "InitExtractor")
 	defer span.End()
 

--- a/tasks/actorstate/init_test.go
+++ b/tasks/actorstate/init_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/go-address"
-	init_ "github.com/filecoin-project/lily/chain/actors/builtin/init"
 	"github.com/filecoin-project/lotus/chain/types"
 	sa0builtin "github.com/filecoin-project/specs-actors/actors/builtin"
 	sa0init "github.com/filecoin-project/specs-actors/actors/builtin/init"
@@ -21,7 +20,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/filecoin-project/lily/lens"
+	init_ "github.com/filecoin-project/lily/chain/actors/builtin/init"
+
 	initmodel "github.com/filecoin-project/lily/model/actors/init"
 	"github.com/filecoin-project/lily/tasks/actorstate"
 )
@@ -78,7 +78,7 @@ func TestInitExtractorV0(t *testing.T) {
 		}
 
 		ex := actorstate.InitExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		is, ok := res.(initmodel.IdAddressList)
@@ -132,7 +132,7 @@ func TestInitExtractorV0(t *testing.T) {
 		}
 
 		ex := actorstate.InitExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		is, ok := res.(initmodel.IdAddressList)
@@ -188,7 +188,7 @@ func TestInitExtractorV2(t *testing.T) {
 		}
 
 		ex := actorstate.InitExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		is, ok := res.(initmodel.IdAddressList)
@@ -242,7 +242,7 @@ func TestInitExtractorV2(t *testing.T) {
 		}
 
 		ex := actorstate.InitExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		is, ok := res.(initmodel.IdAddressList)
@@ -298,7 +298,7 @@ func TestInitExtractorV3(t *testing.T) {
 		}
 
 		ex := actorstate.InitExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		is, ok := res.(initmodel.IdAddressList)
@@ -352,7 +352,7 @@ func TestInitExtractorV3(t *testing.T) {
 		}
 
 		ex := actorstate.InitExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		is, ok := res.(initmodel.IdAddressList)
@@ -408,7 +408,7 @@ func TestInitExtractorV4(t *testing.T) {
 		}
 
 		ex := actorstate.InitExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		is, ok := res.(initmodel.IdAddressList)
@@ -462,7 +462,7 @@ func TestInitExtractorV4(t *testing.T) {
 		}
 
 		ex := actorstate.InitExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		is, ok := res.(initmodel.IdAddressList)

--- a/tasks/actorstate/market.go
+++ b/tasks/actorstate/market.go
@@ -14,7 +14,6 @@ import (
 
 	market "github.com/filecoin-project/lily/chain/actors/builtin/market"
 
-	"github.com/filecoin-project/lily/lens"
 	"github.com/filecoin-project/lily/metrics"
 	"github.com/filecoin-project/lily/model"
 	marketmodel "github.com/filecoin-project/lily/model/actors/market"
@@ -78,7 +77,7 @@ func (m *MarketStateExtractionContext) IsGenesis() bool {
 	return m.CurrTs.Height() == 0
 }
 
-func (m StorageMarketExtractor) Extract(ctx context.Context, a ActorInfo, emsgs []*lens.ExecutedMessage, node ActorStateAPI) (model.Persistable, error) {
+func (m StorageMarketExtractor) Extract(ctx context.Context, a ActorInfo, node ActorStateAPI) (model.Persistable, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "StorageMarketExtractor")
 	defer span.End()
 

--- a/tasks/actorstate/market_test.go
+++ b/tasks/actorstate/market_test.go
@@ -7,10 +7,11 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/lotus/chain/types"
+
 	"github.com/filecoin-project/lily/chain/actors/builtin/market"
 	marketmodel "github.com/filecoin-project/lily/model/actors/market"
 	"github.com/filecoin-project/lily/tasks/actorstate"
-	"github.com/filecoin-project/lotus/chain/types"
 
 	sabuiltin "github.com/filecoin-project/specs-actors/actors/builtin"
 	samarket "github.com/filecoin-project/specs-actors/actors/builtin/market"
@@ -18,7 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/filecoin-project/lily/lens"
 	"github.com/filecoin-project/lily/testutil"
 )
 
@@ -148,7 +148,7 @@ func TestMarketPredicates(t *testing.T) {
 	}
 
 	ex := actorstate.StorageMarketExtractor{}
-	res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+	res, err := ex.Extract(ctx, info, mapi)
 	require.NoError(t, err)
 
 	mtr, ok := res.(*marketmodel.MarketTaskResult)

--- a/tasks/actorstate/miner.go
+++ b/tasks/actorstate/miner.go
@@ -33,7 +33,7 @@ func init() {
 	}
 }
 
-func (m StorageMinerExtractor) Extract(ctx context.Context, a ActorInfo, emsgs []*lens.ExecutedMessage, node ActorStateAPI) (model.Persistable, error) {
+func (m StorageMinerExtractor) Extract(ctx context.Context, a ActorInfo, node ActorStateAPI) (model.Persistable, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "StorageMinerExtractor")
 	if span.IsRecording() {
 		span.SetAttributes(attribute.String("actor", a.Address.String()))
@@ -73,7 +73,7 @@ func (m StorageMinerExtractor) Extract(ctx context.Context, a ActorInfo, emsgs [
 		return nil, xerrors.Errorf("extracting miner sector changes: %w", err)
 	}
 
-	posts, err := ExtractMinerPoSts(ctx, &a, ec, emsgs, node)
+	posts, err := ExtractMinerPoSts(ctx, &a, ec, node)
 	if err != nil {
 		return nil, xerrors.Errorf("extracting miner posts: %v", err)
 	}
@@ -420,7 +420,7 @@ func ExtractMinerSectorData(ctx context.Context, ec *MinerStateExtractionContext
 	return preCommitModel, sectorModel, sectorDealsModel, sectorEventModel, nil
 }
 
-func ExtractMinerPoSts(ctx context.Context, actor *ActorInfo, ec *MinerStateExtractionContext, emsgs []*lens.ExecutedMessage, node ActorStateAPI) (minermodel.MinerSectorPostList, error) {
+func ExtractMinerPoSts(ctx context.Context, actor *ActorInfo, ec *MinerStateExtractionContext, node ActorStateAPI) (minermodel.MinerSectorPostList, error) {
 	_, span := otel.Tracer("").Start(ctx, "ExtractMinerPoSts")
 	defer span.End()
 	// short circuit genesis state, no PoSt messages in genesis blocks.
@@ -498,7 +498,12 @@ func ExtractMinerPoSts(ctx context.Context, actor *ActorInfo, ec *MinerStateExtr
 		return nil
 	}
 
-	for _, msg := range emsgs {
+	tsMsgs, err := node.ExecutedAndBlockMessages(ctx, actor.TipSet, actor.ParentTipSet)
+	if err != nil {
+		return nil, xerrors.Errorf("getting executed and block messages: %w", err)
+	}
+
+	for _, msg := range tsMsgs.Executed {
 		if msg.Message.To == actor.Address && msg.Message.Method == 5 /* miner.SubmitWindowedPoSt */ {
 			if err := processPostMsg(msg); err != nil {
 				return nil, xerrors.Errorf("process post msg: %w", err)

--- a/tasks/actorstate/multisig.go
+++ b/tasks/actorstate/multisig.go
@@ -10,7 +10,6 @@ import (
 	"github.com/filecoin-project/lily/chain/actors/adt"
 	"github.com/filecoin-project/lily/chain/actors/builtin/multisig"
 
-	"github.com/filecoin-project/lily/lens"
 	"github.com/filecoin-project/lily/metrics"
 	"github.com/filecoin-project/lily/model"
 	multisigmodel "github.com/filecoin-project/lily/model/actors/multisig"
@@ -24,7 +23,7 @@ func init() {
 
 type MultiSigActorExtractor struct{}
 
-func (m MultiSigActorExtractor) Extract(ctx context.Context, a ActorInfo, emsgs []*lens.ExecutedMessage, node ActorStateAPI) (model.Persistable, error) {
+func (m MultiSigActorExtractor) Extract(ctx context.Context, a ActorInfo, node ActorStateAPI) (model.Persistable, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "MultiSigActor")
 	defer span.End()
 

--- a/tasks/actorstate/multisig_test.go
+++ b/tasks/actorstate/multisig_test.go
@@ -23,7 +23,6 @@ import (
 	adt3 "github.com/filecoin-project/specs-actors/v3/actors/util/adt"
 	sa4builtin "github.com/filecoin-project/specs-actors/v4/actors/builtin"
 
-	"github.com/filecoin-project/lily/lens"
 	multisigmodel "github.com/filecoin-project/lily/model/actors/multisig"
 	"github.com/filecoin-project/lily/tasks/actorstate"
 )
@@ -93,7 +92,7 @@ func TestMultisigExtractorV0(t *testing.T) {
 		}
 
 		ex := actorstate.MultiSigActorExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		ms, ok := res.(*multisigmodel.MultisigTaskResult)
@@ -179,7 +178,7 @@ func TestMultisigExtractorV0(t *testing.T) {
 		}
 
 		ex := actorstate.MultiSigActorExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		ms, ok := res.(*multisigmodel.MultisigTaskResult)
@@ -238,7 +237,7 @@ func TestMultisigExtractorV0(t *testing.T) {
 		}
 
 		ex := actorstate.MultiSigActorExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		ms, ok := res.(*multisigmodel.MultisigTaskResult)
@@ -321,7 +320,7 @@ func TestMultisigExtractorV2(t *testing.T) {
 		}
 
 		ex := actorstate.MultiSigActorExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		ms, ok := res.(*multisigmodel.MultisigTaskResult)
@@ -407,7 +406,7 @@ func TestMultisigExtractorV2(t *testing.T) {
 		}
 
 		ex := actorstate.MultiSigActorExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		ms, ok := res.(*multisigmodel.MultisigTaskResult)
@@ -466,7 +465,7 @@ func TestMultisigExtractorV2(t *testing.T) {
 		}
 
 		ex := actorstate.MultiSigActorExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		ms, ok := res.(*multisigmodel.MultisigTaskResult)
@@ -552,7 +551,7 @@ func TestMultisigExtractorV3(t *testing.T) {
 		}
 
 		ex := actorstate.MultiSigActorExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		ms, ok := res.(*multisigmodel.MultisigTaskResult)
@@ -638,7 +637,7 @@ func TestMultisigExtractorV3(t *testing.T) {
 		}
 
 		ex := actorstate.MultiSigActorExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		ms, ok := res.(*multisigmodel.MultisigTaskResult)
@@ -697,7 +696,7 @@ func TestMultisigExtractorV3(t *testing.T) {
 		}
 
 		ex := actorstate.MultiSigActorExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		ms, ok := res.(*multisigmodel.MultisigTaskResult)
@@ -783,7 +782,7 @@ func TestMultisigExtractorV4(t *testing.T) {
 		}
 
 		ex := actorstate.MultiSigActorExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		ms, ok := res.(*multisigmodel.MultisigTaskResult)
@@ -869,7 +868,7 @@ func TestMultisigExtractorV4(t *testing.T) {
 		}
 
 		ex := actorstate.MultiSigActorExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		ms, ok := res.(*multisigmodel.MultisigTaskResult)
@@ -928,7 +927,7 @@ func TestMultisigExtractorV4(t *testing.T) {
 		}
 
 		ex := actorstate.MultiSigActorExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		ms, ok := res.(*multisigmodel.MultisigTaskResult)

--- a/tasks/actorstate/power.go
+++ b/tasks/actorstate/power.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/filecoin-project/lily/chain/actors/builtin/power"
 
-	"github.com/filecoin-project/lily/lens"
 	"github.com/filecoin-project/lily/metrics"
 	"github.com/filecoin-project/lily/model"
 	powermodel "github.com/filecoin-project/lily/model/actors/power"
@@ -76,7 +75,7 @@ func (p *PowerStateExtractionContext) HasPreviousState() bool {
 	return !(p.CurrTs.Height() == 1 || p.PrevState == p.CurrState)
 }
 
-func (StoragePowerExtractor) Extract(ctx context.Context, a ActorInfo, emsgs []*lens.ExecutedMessage, node ActorStateAPI) (model.Persistable, error) {
+func (StoragePowerExtractor) Extract(ctx context.Context, a ActorInfo, node ActorStateAPI) (model.Persistable, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "StoragePowerExtractor")
 	defer span.End()
 

--- a/tasks/actorstate/power_test.go
+++ b/tasks/actorstate/power_test.go
@@ -11,8 +11,9 @@ import (
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 
-	"github.com/filecoin-project/lily/chain/actors/builtin/power"
 	"github.com/filecoin-project/lotus/chain/types"
+
+	"github.com/filecoin-project/lily/chain/actors/builtin/power"
 
 	sa0builtin "github.com/filecoin-project/specs-actors/actors/builtin"
 	power0 "github.com/filecoin-project/specs-actors/actors/builtin/power"
@@ -28,7 +29,6 @@ import (
 	sa4builtin "github.com/filecoin-project/specs-actors/v4/actors/builtin"
 	sa4smoothing "github.com/filecoin-project/specs-actors/v4/actors/util/smoothing"
 
-	"github.com/filecoin-project/lily/lens"
 	powermodel "github.com/filecoin-project/lily/model/actors/power"
 	"github.com/filecoin-project/lily/tasks/actorstate"
 )
@@ -69,7 +69,7 @@ func TestPowerExtractV0(t *testing.T) {
 		}
 
 		ex := actorstate.StoragePowerExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		cp, ok := res.(*powermodel.PowerTaskResult)
@@ -124,7 +124,7 @@ func TestPowerExtractV0(t *testing.T) {
 		}
 
 		ex := actorstate.StoragePowerExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		cp, ok := res.(*powermodel.PowerTaskResult)
@@ -173,7 +173,7 @@ func TestPowerExtractV2(t *testing.T) {
 		}
 
 		ex := actorstate.StoragePowerExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		cp, ok := res.(*powermodel.PowerTaskResult)
@@ -229,7 +229,7 @@ func TestPowerExtractV2(t *testing.T) {
 		}
 
 		ex := actorstate.StoragePowerExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		cp, ok := res.(*powermodel.PowerTaskResult)
@@ -278,7 +278,7 @@ func TestPowerExtractV3(t *testing.T) {
 		}
 
 		ex := actorstate.StoragePowerExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		cp, ok := res.(*powermodel.PowerTaskResult)
@@ -334,7 +334,7 @@ func TestPowerExtractV3(t *testing.T) {
 		}
 
 		ex := actorstate.StoragePowerExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		cp, ok := res.(*powermodel.PowerTaskResult)
@@ -383,7 +383,7 @@ func TestPowerExtractV4(t *testing.T) {
 		}
 
 		ex := actorstate.StoragePowerExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		cp, ok := res.(*powermodel.PowerTaskResult)
@@ -439,7 +439,7 @@ func TestPowerExtractV4(t *testing.T) {
 		}
 
 		ex := actorstate.StoragePowerExtractor{}
-		res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+		res, err := ex.Extract(ctx, info, mapi)
 		require.NoError(t, err)
 
 		cp, ok := res.(*powermodel.PowerTaskResult)

--- a/tasks/actorstate/reward.go
+++ b/tasks/actorstate/reward.go
@@ -3,10 +3,10 @@ package actorstate
 import (
 	"context"
 
-	"github.com/filecoin-project/lily/chain/actors/builtin/reward"
 	"go.opentelemetry.io/otel"
 
-	"github.com/filecoin-project/lily/lens"
+	"github.com/filecoin-project/lily/chain/actors/builtin/reward"
+
 	"github.com/filecoin-project/lily/metrics"
 	"github.com/filecoin-project/lily/model"
 	rewardmodel "github.com/filecoin-project/lily/model/actors/reward"
@@ -23,7 +23,7 @@ func init() {
 	}
 }
 
-func (RewardExtractor) Extract(ctx context.Context, a ActorInfo, emsgs []*lens.ExecutedMessage, node ActorStateAPI) (model.Persistable, error) {
+func (RewardExtractor) Extract(ctx context.Context, a ActorInfo, node ActorStateAPI) (model.Persistable, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "RewardExtractor")
 	defer span.End()
 

--- a/tasks/actorstate/reward_test.go
+++ b/tasks/actorstate/reward_test.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
-	"github.com/filecoin-project/lily/chain/actors/builtin/power"
-	"github.com/filecoin-project/lily/chain/actors/builtin/reward"
 	"github.com/filecoin-project/lotus/chain/types"
 	tutils "github.com/filecoin-project/specs-actors/support/testing"
 
-	"github.com/filecoin-project/lily/lens"
+	"github.com/filecoin-project/lily/chain/actors/builtin/power"
+	"github.com/filecoin-project/lily/chain/actors/builtin/reward"
+
 	rewardmodel "github.com/filecoin-project/lily/model/actors/reward"
 	"github.com/filecoin-project/lily/tasks/actorstate"
 
@@ -57,7 +57,7 @@ func TestRewardExtractV0(t *testing.T) {
 	}
 
 	ex := actorstate.RewardExtractor{}
-	res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+	res, err := ex.Extract(ctx, info, mapi)
 	require.NoError(t, err)
 
 	cr, ok := res.(*rewardmodel.ChainReward)
@@ -106,7 +106,7 @@ func TestRewardExtractV2(t *testing.T) {
 	}
 
 	ex := actorstate.RewardExtractor{}
-	res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+	res, err := ex.Extract(ctx, info, mapi)
 	require.NoError(t, err)
 
 	cr, ok := res.(*rewardmodel.ChainReward)
@@ -155,7 +155,7 @@ func TestRewardExtractV3(t *testing.T) {
 	}
 
 	ex := actorstate.RewardExtractor{}
-	res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+	res, err := ex.Extract(ctx, info, mapi)
 	require.NoError(t, err)
 
 	cr, ok := res.(*rewardmodel.ChainReward)
@@ -204,7 +204,7 @@ func TestRewardExtractV4(t *testing.T) {
 	}
 
 	ex := actorstate.RewardExtractor{}
-	res, err := ex.Extract(ctx, info, []*lens.ExecutedMessage{}, mapi)
+	res, err := ex.Extract(ctx, info, mapi)
 	require.NoError(t, err)
 
 	cr, ok := res.(*rewardmodel.ChainReward)

--- a/tasks/actorstate/task.go
+++ b/tasks/actorstate/task.go
@@ -12,7 +12,6 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/lily/chain/actors/builtin"
-	"github.com/filecoin-project/lily/lens"
 	"github.com/filecoin-project/lily/metrics"
 	"github.com/filecoin-project/lily/model"
 	visormodel "github.com/filecoin-project/lily/model/visor"
@@ -34,7 +33,7 @@ func NewTask(node tasks.DataSource, extracterMap ActorExtractorMap) *Task {
 	return p
 }
 
-func (t *Task) ProcessActors(ctx context.Context, ts *types.TipSet, pts *types.TipSet, candidates tasks.ActorStateChangeDiff, emsgs []*lens.ExecutedMessage) (model.Persistable, *visormodel.ProcessingReport, error) {
+func (t *Task) ProcessActors(ctx context.Context, ts *types.TipSet, pts *types.TipSet, candidates tasks.ActorStateChangeDiff) (model.Persistable, *visormodel.ProcessingReport, error) {
 	log.Debugw("processing actor state changes", "height", ts.Height(), "parent_height", pts.Height())
 
 	report := &visormodel.ProcessingReport{
@@ -68,7 +67,7 @@ func (t *Task) ProcessActors(ctx context.Context, ts *types.TipSet, pts *types.T
 	// Run each task concurrently
 	results := make(chan *ActorStateResult, len(actors))
 	for addr, ch := range actors {
-		go t.runActorStateExtraction(ctx, ts, pts, addr, ch, emsgs, results)
+		go t.runActorStateExtraction(ctx, ts, pts, addr, ch, results)
 	}
 
 	// Gather results
@@ -111,7 +110,7 @@ func (t *Task) ProcessActors(ctx context.Context, ts *types.TipSet, pts *types.T
 	return data, report, nil
 }
 
-func (t *Task) runActorStateExtraction(ctx context.Context, ts *types.TipSet, pts *types.TipSet, addrStr string, ch tasks.ActorStateChange, emsgs []*lens.ExecutedMessage, results chan *ActorStateResult) {
+func (t *Task) runActorStateExtraction(ctx context.Context, ts *types.TipSet, pts *types.TipSet, addrStr string, ch tasks.ActorStateChange, results chan *ActorStateResult) {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.ActorCode, builtin.ActorNameByCode(ch.Actor.Code)))
 
 	res := &ActorStateResult{
@@ -144,7 +143,7 @@ func (t *Task) runActorStateExtraction(ctx context.Context, ts *types.TipSet, pt
 		res.SkippedParse = true
 	} else {
 		// Parse state
-		data, err := extracter.Extract(ctx, info, emsgs, t.node)
+		data, err := extracter.Extract(ctx, info, t.node)
 		if err != nil {
 			res.Error = xerrors.Errorf("failed to extract parsed actor state: %w", err)
 			return

--- a/tasks/actorstate/verifreg.go
+++ b/tasks/actorstate/verifreg.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/filecoin-project/lily/chain/actors/adt"
 	"github.com/filecoin-project/lily/chain/actors/builtin/verifreg"
-	"github.com/filecoin-project/lily/lens"
 	"github.com/filecoin-project/lily/metrics"
 	"github.com/filecoin-project/lily/model"
 )
@@ -75,7 +74,7 @@ func NewVerifiedRegistryExtractorContext(ctx context.Context, a ActorInfo, node 
 	}, nil
 }
 
-func (VerifiedRegistryExtractor) Extract(ctx context.Context, a ActorInfo, emsgs []*lens.ExecutedMessage, node ActorStateAPI) (model.Persistable, error) {
+func (VerifiedRegistryExtractor) Extract(ctx context.Context, a ActorInfo, node ActorStateAPI) (model.Persistable, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "VerifiedRegistryExtractor")
 	defer span.End()
 

--- a/tasks/messageexecutions/message.go
+++ b/tasks/messageexecutions/message.go
@@ -3,31 +3,30 @@ package messageexecutions
 import (
 	"context"
 
-	"github.com/filecoin-project/lily/chain/actors/adt"
-	"github.com/filecoin-project/lily/lens"
-	"github.com/filecoin-project/lily/lens/util"
-	"github.com/filecoin-project/lily/model"
-	messagemodel "github.com/filecoin-project/lily/model/messages"
-	visormodel "github.com/filecoin-project/lily/model/visor"
-	"github.com/filecoin-project/lily/tasks/messages"
 	"github.com/filecoin-project/lotus/chain/types"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/lily/lens/util"
+	"github.com/filecoin-project/lily/model"
+	messagemodel "github.com/filecoin-project/lily/model/messages"
+	visormodel "github.com/filecoin-project/lily/model/visor"
+	"github.com/filecoin-project/lily/tasks"
+	"github.com/filecoin-project/lily/tasks/messages"
 )
 
-func NewTask() *Task {
-	return &Task{}
-}
-
 type Task struct {
+	node tasks.DataSource
 }
 
-func (p *Task) Close() error {
-	return nil
+func NewTask(node tasks.DataSource) *Task {
+	return &Task{
+		node: node,
+	}
 }
 
-func (p *Task) ProcessMessageExecutions(ctx context.Context, store adt.Store, ts *types.TipSet, pts *types.TipSet, mex []*lens.MessageExecution) (model.Persistable, *visormodel.ProcessingReport, error) {
+func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types.TipSet) (model.Persistable, *visormodel.ProcessingReport, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "ProcessMessageExecutions")
 	if span.IsRecording() {
 		span.SetAttributes(attribute.String("tipset", ts.String()), attribute.Int64("height", int64(ts.Height())))
@@ -37,6 +36,12 @@ func (p *Task) ProcessMessageExecutions(ctx context.Context, store adt.Store, ts
 	report := &visormodel.ProcessingReport{
 		Height:    int64(pts.Height()),
 		StateRoot: pts.ParentState().String(),
+	}
+
+	mex, err := p.node.MessageExecutions(ctx, ts, pts)
+	if err != nil {
+		report.ErrorsDetected = xerrors.Errorf("getting messages executions for tipset: %w", err)
+		return nil, report, nil
 	}
 
 	var (
@@ -93,73 +98,11 @@ func (p *Task) ProcessMessageExecutions(ctx context.Context, store adt.Store, ts
 			})
 		}
 
-		// TODO(frrist): this code is commented out as it collects all internal message sent through the VM.
-		// Currently there does not exist a need for message analysis at this granularity.
-		// Before enabling this, some type of filtering will need to be implemented such that only
-		// the internal sends we are interested in can be extracted.
-		/*
-			getActorCode, err := util.MakeGetActorCodeFunc(ctx, store, ts, pts)
-			if err != nil {
-				return nil, nil, err
-			}
-
-			// some messages will cause internal messages to be sent between the actors, gather and record them here.
-			subCalls := getChildMessagesOf(m)
-			for _, sub := range subCalls {
-				subToActorCode, found := getActorCode(sub.Message.To)
-				var subToName, subToFamily string
-				if found {
-					subToName, subToFamily, err = util.ActorNameAndFamilyFromCode(subToActorCode)
-					if err != nil {
-						errorsDetected = append(errorsDetected, &messages.MessageError{
-							Cid:   sub.Message.Cid(),
-							Error: xerrors.Errorf("failed to get sub-message to actor name and family: %w", err).Error(),
-						})
-					}
-					// if the message aborted execution while creating an actor due to lack of gas then this is expected as the actors don't exist
-				} else {
-					subToName = "<unknown>"
-					subToFamily = "<unknown>"
-				}
-				internalResult = append(internalResult, &messagemodel.InternalMessage{
-					Height:        int64(m.Height),
-					Cid:           sub.Message.Cid().String(), // pity we have to calculate this here
-					StateRoot:     m.StateRoot.String(),       // state root of the parent message
-					SourceMessage: m.Cid.String(),
-					From:          sub.Message.From.String(),
-					To:            sub.Message.To.String(),
-					Value:         sub.Message.Value.String(),
-					Method:        uint64(sub.Message.Method),
-					ActorName:     subToName,
-					ActorFamily:   subToFamily,
-					ExitCode:      int64(sub.Receipt.ExitCode),
-					GasUsed:       sub.Receipt.GasUsed,
-				})
-
-				subMethod, subParams, err := util.MethodAndParamsForMessage(sub.Message, subToActorCode)
-				if err != nil {
-					errorsDetected = append(errorsDetected, &messages.MessageError{
-						Cid:   sub.Message.Cid(),
-						Error: xerrors.Errorf("failed parse method and params for sub-message: %w", err).Error(),
-					})
-				}
-				internalParsedResult = append(internalParsedResult, &messagemodel.InternalParsedMessage{
-					Height: int64(m.Height),
-					Cid:    m.Cid.String(),
-					From:   m.Message.From.String(),
-					To:     m.Message.To.String(),
-					Value:  m.Message.Value.String(),
-					Method: subMethod,
-					Params: subParams,
-				})
-			}
-		*/
 	}
 	if len(errorsDetected) != 0 {
 		report.ErrorsDetected = errorsDetected
 	}
 	return model.PersistableList{
-
 		internalResult,
 		internalParsedResult,
 	}, report, nil

--- a/tasks/messages/message.go
+++ b/tasks/messages/message.go
@@ -2,8 +2,10 @@ package messages
 
 import (
 	"context"
+	"math"
+	"math/big"
+
 	"github.com/filecoin-project/go-state-types/exitcode"
-	"github.com/filecoin-project/lily/lens/util"
 	"github.com/filecoin-project/lotus/build"
 	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
@@ -11,25 +13,29 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/xerrors"
-	"math"
-	"math/big"
+
+	"github.com/filecoin-project/lily/lens/util"
+	"github.com/filecoin-project/lily/tasks"
 
 	"github.com/filecoin-project/lily/chain/actors/builtin"
-	"github.com/filecoin-project/lily/lens"
 	"github.com/filecoin-project/lily/model"
 	derivedmodel "github.com/filecoin-project/lily/model/derived"
 	messagemodel "github.com/filecoin-project/lily/model/messages"
 	visormodel "github.com/filecoin-project/lily/model/visor"
 )
 
-type Task struct{}
+type Task struct {
+	node tasks.DataSource
+}
 
-func NewTask() *Task {
-	return &Task{}
+func NewTask(node tasks.DataSource) *Task {
+	return &Task{
+		node: node,
+	}
 }
 
 // Note that pts is the parent tipset containing the messages, ts is the following tipset containing the receipts
-func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types.TipSet, emsgs []*lens.ExecutedMessage, blkMsgs []*lens.BlockMessages) (model.Persistable, *visormodel.ProcessingReport, error) {
+func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types.TipSet) (model.Persistable, *visormodel.ProcessingReport, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "ProcessMessages")
 	if span.IsRecording() {
 		span.SetAttributes(attribute.String("tipset", ts.String()), attribute.Int64("height", int64(ts.Height())))
@@ -40,6 +46,14 @@ func (p *Task) ProcessMessages(ctx context.Context, ts *types.TipSet, pts *types
 		Height:    int64(pts.Height()),
 		StateRoot: pts.ParentState().String(),
 	}
+
+	tsMsgs, err := p.node.ExecutedAndBlockMessages(ctx, ts, pts)
+	if err != nil {
+		report.ErrorsDetected = xerrors.Errorf("getting executed and block messages: %w", err)
+		return nil, report, nil
+	}
+	emsgs := tsMsgs.Executed
+	blkMsgs := tsMsgs.Block
 
 	var (
 		messageResults       = make(messagemodel.Messages, 0, len(emsgs))

--- a/tasks/messages/message_test.go
+++ b/tasks/messages/message_test.go
@@ -4,15 +4,18 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"reflect"
+	"testing"
+
 	"github.com/filecoin-project/go-bitfield"
 	"github.com/filecoin-project/go-state-types/cbor"
 	"github.com/filecoin-project/go-state-types/crypto"
+	market0 "github.com/filecoin-project/specs-actors/actors/builtin/market"
+
 	"github.com/filecoin-project/lily/chain/actors/builtin"
 	"github.com/filecoin-project/lily/chain/actors/builtin/market"
 	miner "github.com/filecoin-project/lily/chain/actors/builtin/miner"
-	market0 "github.com/filecoin-project/specs-actors/actors/builtin/market"
-	"reflect"
-	"testing"
+	"github.com/filecoin-project/lily/lens/util"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
@@ -237,8 +240,6 @@ func TestParseMessageParams(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			task := NewTask()
-
 			to, _ := address.NewIDAddress(1)
 			from, _ := address.NewIDAddress(2)
 
@@ -250,7 +251,7 @@ func TestParseMessageParams(t *testing.T) {
 				Params: tc.params,
 			}
 
-			method, encoded, err := task.parseMessageParams(msg, tc.actorCode)
+			method, encoded, err := util.MethodAndParamsForMessage(msg, tc.actorCode)
 			switch {
 			case tc.wantErr && err == nil:
 				t.Errorf("got no error but wanted one")


### PR DESCRIPTION
### What
This PR targets the `indexer-refactor` branch.
This PR aims to keep indexer behavior consistent with the current while landing some refactor work to improve code extensibility.
- embed `GetExecutedAndBlockMessagesForTipset` in processors, preventing unnecessary (and expensive!) calls to the method when its output isn't used. And example of this would be running all actor tasks excluding the miner actor. Prior changes [here](https://github.com/filecoin-project/lily/pull/849/files#diff-88c7f968b3518b2c701d948daf6e103fdc0b57c3525a8e24f19645ae5c1d74c6R96-R115) ensure multiple calls to this method are only executed once, returning a cached value for subsequent calls. This change also makes the indexer's logic more concise.
- embed `GetMessageExecutions` in processors, taking advantage of the memoized method pattern used in previous commit. This has the added bonus of removing the `ProcessMessageExecution` interface and fitting the messege execution task under the `ProcessMessages` interface.

Follow on: https://github.com/filecoin-project/lily/pull/871