### PR TITLE
feat(ci): Continuous deployment for tags and deploy branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,50 +56,56 @@ commands:
       - run:
           name: Run lily within the docker image
           command: docker run --rm filecoin/lily:latest --version
-  publish-docker-from-branch-production:
+
+jobs:
+  publish-production-image-from-branch-for-mainnet:
+    executor: dockerizer
     steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+          version: "20.10.6"
       - run:
-          name: Publish Mainnet Production Docker Image to Docker Hub
+          name: Publish Mainnet Production Docker Image from Lily branch to Docker Hub
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
             LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_BRANCH//\//-}-${tag_suffix} make docker-mainnet-push
+  publish-production-image-from-branch-for-calibnet:
+    executor: dockerizer
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+          version: "20.10.6"
       - run:
-          name: Publish Calibnet Production Docker Image to Docker Hub
+          name: Publish Calibnet Production Docker Image from Lily branch to Docker Hub
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
             LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_BRANCH//\//-}-${tag_suffix}-calibnet make docker-calibnet-push
-      - run:
-          name: Publish Butterflynet Dev Docker Image to Docker Hub
-          command: |
-            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
-            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_BRANCH//\//-}-${tag_suffix}-butterflynet-dev make docker-butterflynet-dev-push
-  publish-docker-from-branch-dev:
+  publish-production-image-from-branch-for-butterflynet:
+    executor: dockerizer
     steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+          version: "20.10.6"
       - run:
-          name: Publish Mainnet Dev Docker Image to Docker Hub
+          name: Publish Butterflynet Production Docker Image from Lily branch to Docker Hub
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
-            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_BRANCH//\//-}-${tag_suffix}-dev make docker-mainnet-dev-push
-      - run:
-          name: Publish Calibnet Dev Docker Image to Docker Hub
-          command: |
-            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
-            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_BRANCH//\//-}-${tag_suffix}-calibnet-dev make docker-calibnet-dev-push
-      - run:
-          name: Publish Butterflynet Dev Docker Image to Docker Hub
-          command: |
-            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
-            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_BRANCH//\//-}-${tag_suffix}-butterflynet-dev make docker-butterflynet-dev-push
-  publish-docker-semver-production:
+            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_BRANCH//\//-}-${tag_suffix}-butterflynet make docker-butterflynet-push
+  publish-production-image-from-semver-tag-for-mainnet:
+    executor: dockerizer
     steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+          version: "20.10.6"
       - run:
-          name: Publish Mainnet Production Semver Docker Image to Docker Hub
+          name: Publish Mainnet Production Docker Image from Lily semver tag to Docker Hub
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_TAG//\//-} make docker-mainnet-push
@@ -107,8 +113,15 @@ commands:
             if [[ ! "$CIRCLE_TAG" =~ -rc[0-9]+$ ]]; then
               LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=latest make docker-mainnet-push
             fi
+  publish-production-image-from-semver-tag-for-calibnet:
+    executor: dockerizer
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+          version: "20.10.6"
       - run:
-          name: Publish Calibnet Production Semver Docker Image to Docker Hub
+          name: Publish Calibnet Production Docker Image from Lily semver tag to Docker Hub
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_TAG//\//-}-calibnet make docker-calibnet-push
@@ -116,8 +129,15 @@ commands:
             if [[ ! "$CIRCLE_TAG" =~ -rc[0-9]+$ ]]; then
               LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=calibnet-latest make docker-calibnet-push
             fi
+  publish-production-image-from-semver-tag-for-butterflynet:
+    executor: dockerizer
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+          version: "20.10.6"
       - run:
-          name: Publish Butterflynet Production Semver Docker Image to Docker Hub
+          name: Publish Butterflynet Production Docker Image from Lily semver tag to Docker Hub
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_TAG//\//-}-butterfly make docker-butterfly-push
@@ -125,50 +145,13 @@ commands:
             if [[ ! "$CIRCLE_TAG" =~ -rc[0-9]+$ ]]; then
               LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=butterfly-latest make docker-butterfly-push
             fi
-  publish-docker-semver-dev:
-    steps:
-      - run:
-          name: Publish Mainnet Dev Semver Docker Image to Docker Hub
-          command: |
-            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_TAG//\//-}-dev make docker-mainnet-dev-push
-      - run:
-          name: Publish Calibnet Dev Semver Docker Image to Docker Hub
-          command: |
-            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_TAG//\//-}-calibnet-dev make docker-calibnet-dev-push
-      - run:
-          name: Publish Butterflynet Dev Semver Docker Image to Docker Hub
-          command: |
-            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_TAG//\//-}-butterflynet-dev make docker-butterflynet-dev-push
-
-jobs:
-  publish-docker-from-branch:
-    executor: dockerizer
-    steps:
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-          version: "20.10.6"
-      - publish-docker-from-branch-dev
-      - publish-docker-from-branch-production
-  publish-docker-from-tag:
-    executor: dockerizer
-    steps:
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-          version: "20.10.6"
-      - publish-docker-semver-dev
-      - publish-docker-semver-production
   # duplicated jobs are for making these jobs' descriptions
   # in the pipelines within the CircleCI less confusing
-  trigger-tag-deployment:
+  trigger-branch-deployment-for-all-networks:
     executor: dockerizer
     steps:
       - trigger-deployment
-  trigger-branch-deployment:
+  trigger-semver-tag-deployment-for-all-networks:
     executor: dockerizer
     steps:
       - trigger-deployment
@@ -343,6 +326,19 @@ jobs:
           command: make docker-calibnet-dev
       - validate-docker-executeable
 
+
+branch_filters: &branch_filters
+  branches:
+    only: /deploy/
+  tags:
+    ignore: /.*/
+
+tag_filters: &tag_filters
+  branches:
+    ignore: /.*/
+  tags:
+    only: /^(v[0-9]+\.[0-9]+\.[0-9]+|.*dev.*)(-rc[0-9]+)*$/  # incl v0.0.0 or v0.0.0-rc0 or containing w `dev`
+
 workflows:
   version: 2
   check:
@@ -358,38 +354,42 @@ workflows:
       - test-docker-calibnet-dev
   build-docker-images:
     jobs:
-      - publish-docker-from-branch:
-          # build and push docker image from branch
+      - publish-production-image-from-branch-for-mainnet:
           filters:
-            branches:
-              only: /^(master|main|deploy)$/
-            tags:
-              ignore: /.*/
-      - trigger-branch-deployment:
+            <<: *branch_filters
+      - publish-production-image-from-branch-for-calibnet:
+          filters:
+            <<: *branch_filters
+      - publish-production-image-from-branch-for-butterflynet:
+          filters:
+            <<: *branch_filters
+      - trigger-branch-deployment-for-all-networks:
           requires:
-            - publish-docker-from-branch
+            - publish-production-image-from-branch-for-mainnet
+            - publish-production-image-from-branch-for-calibnet
+            - publish-production-image-from-branch-for-butterflynet
           filters:
-            branches:
-              # this filters which branches get deployed
-              # should be within the set of the dependent (required) publish step
-              only: /^(master|main|deploy)$/
-            tags:
-              ignore: /.*/
-      - publish-docker-from-tag:
-          # build and push semver tags docker image
+            <<: *branch_filters
+      - publish-production-image-from-semver-tag-for-mainnet:
           filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^(v[0-9]+\.[0-9]+\.[0-9]+|.*dev.*)(-rc[0-9]+)*$/  # incl v0.0.0 or v0.0.0-rc0 or containing w `dev`
-      - trigger-tag-deployment:
+            <<: *tag_filters
+      - publish-production-image-from-semver-tag-for-calibnet:
+          filters:
+            <<: *tag_filters
+      - publish-production-image-from-semver-tag-for-butterflynet:
+          filters:
+            <<: *tag_filters
+      - trigger-semver-tag-deployment-for-all-networks:
           requires:
-            - publish-docker-from-tag
+            - publish-production-image-from-semver-tag-for-mainnet
+            - publish-production-image-from-semver-tag-for-calibnet
+            - publish-production-image-from-semver-tag-for-butterflynet
           filters:
             branches:
               ignore: /.*/
             # this filters which tags get deployed
             # should be within the set of dependent (required) publish step
+            # ONLY deploy semver tags with `dev` in the name for now
             tags:
               only: /.*dev.*/ # any tag containing `dev`
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,22 @@ commands:
       - run: git submodule sync
       - run: sudo apt-get install gcc libc-dev
       - run: git submodule update --init
+  trigger-deployment:
+    steps:
+      - run:
+          name: Trigger deployment for filecoin-project/lily
+          command: |
+            # derive docker image deploy-tag according to the publish-* steps in this config
+            tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
+            deploy_branch=${CIRCLE_BRANCH}-$tag_suffix
+            deploy_target=${CIRCLE_TAG:-deploy_branch}
+
+            # trigger deployment in sentinel-infra repo
+            curl --request POST \
+              --url https://circleci.com/api/v2/project/gh/filecoin-project/sentinel-infra/pipeline \
+              --header "Circle-Token: $SENTINEL_INFRA_CIRCLECI_API_TOKEN " \
+              --header "content-type: application/json" \
+              --data '{"branch":"master","parameters":{"trigger-deploy": true, "deploy-tag":"$deploy_target"}}'
   validate-docker-executeable:
     steps:
       - run:
@@ -102,7 +118,7 @@ commands:
             LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_TAG//\//-}-calibnet-dev make docker-calibnet-dev-push
 
 jobs:
-  publish-docker-from-master:
+  publish-docker-from-branch:
     executor: dockerizer
     steps:
       - checkout
@@ -120,6 +136,10 @@ jobs:
           version: "20.10.6"
       - publish-docker-semver-dev
       - publish-docker-semver-production
+  trigger-deployment:
+    executor: dockerizer
+    steps:
+      - trigger-deployment
   mod-tidy-check:
     executor: golang
     steps:
@@ -305,14 +325,22 @@ workflows:
       - test-docker-calibnet
       - test-docker-calibnet-dev
   build-docker-images:
-    # `build-push-*` runs on master or main branches and tags that look like semver
-    # see: https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag
     jobs:
-      - publish-docker-from-master:
-          # build and push latest master docker image
+      - publish-docker-from-branch:
+          # build and push docker image from branch
           filters:
             branches:
-              only: /^(master|main)$/
+              only: /^(master|main|deploy)$/
+            tags:
+              ignore: /.*/
+      - trigger-deployment:
+          requires:
+            - publish-docker-from-branch
+          filters:
+            branches:
+              # this filters which branches get deployed
+              # should be within the set of the dependent (required) publish step
+              only: /^(master|main|deploy)$/
             tags:
               ignore: /.*/
       - publish-docker-from-tag:
@@ -321,5 +349,15 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)*/  # incl v0.0.0 or v0.0.0-rc0
+              only: /^(v[0-9]+\.[0-9]+\.[0-9]+|.*dev.*)(-rc[0-9]+)*$/  # incl v0.0.0 or v0.0.0-rc0 or containing w `dev`
+      - trigger-deployment:
+          requires:
+            - publish-docker-from-tag
+          filters:
+            branches:
+              ignore: /.*/
+            # this filters which tags get deployed
+            # should be within the set of dependent (required) publish step
+            tags:
+              only: /.*dev.*/ # any tag containing `dev`
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,8 @@ jobs:
             sanitized_tag=`echo $CIRCLE_TAG | sed 's:/:-:g'`
             LILY_IMAGE_TAG=$sanitized_tag make docker-mainnet-push
             # omit release candidates from pushing latest
-            if [[ ! "$CIRCLE_TAG" =~ -rc[0-9]+$ ]]; then
+            # only semver releases are pushing mainnet-latest
+            if [[ "$CIRCLE_TAG" =~ ^(v[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
               LILY_IMAGE_TAG=latest make docker-mainnet-push
             fi
   publish-production-image-from-semver-tag-for-calibnet:
@@ -147,9 +148,9 @@ jobs:
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             sanitized_tag=`echo $CIRCLE_TAG | sed 's:/:-:g'`
-            LILY_IMAGE_TAG=$sanitized_tag make docker-calibnet-push
-            # omit release candidates from pushing calibnet-latest
-            if [[ ! "$CIRCLE_TAG" =~ -rc[0-9]+$ ]]; then
+            LILY_IMAGE_TAG=$sanitized_tag-calibnet make docker-calibnet-push
+            # only semver releases are pushing calibnet-latest
+            if [[ "$CIRCLE_TAG" =~ ^(v[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
               LILY_IMAGE_TAG=calibnet-latest make docker-calibnet-push
             fi
   publish-production-image-from-semver-tag-for-butterflynet:
@@ -164,9 +165,9 @@ jobs:
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             sanitized_tag=`echo $CIRCLE_TAG | sed 's:/:-:g'`
-            LILY_IMAGE_TAG=$sanitized_tag-butterfly make docker-butterflynet-push
-            # omit release candidates from pushing butterflynet-latest
-            if [[ ! "$CIRCLE_TAG" =~ -rc[0-9]+$ ]]; then
+            LILY_IMAGE_TAG=$sanitized_tag-butterflynet make docker-butterflynet-push
+            # only semver releases are pushing butterflynet-latest
+            if [[ "$CIRCLE_TAG" =~ ^(v[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
               LILY_IMAGE_TAG=butterflynet-latest make docker-butterflynet-push
             fi
   # duplicated jobs are for making these jobs' descriptions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ commands:
               OUTPUT_FILE=$(mktemp)
               HTTP_CODE=$(curl --silent --output $OUTPUT_FILE --write-out "%{http_code}" "$@")
               if [[ ${HTTP_CODE} -lt 200 || ${HTTP_CODE} -gt 299 ]] ; then
-                >&2 cat $OUTPUT_FILE && echo ""
+                >&2 cat $OUTPUT_FILE
                 return 22
               fi
               cat $OUTPUT_FILE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,12 @@ commands:
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
             LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_BRANCH//\//-}-${tag_suffix}-calibnet make docker-calibnet-push
+      - run:
+          name: Publish Butterflynet Dev Docker Image to Docker Hub
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
+            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_BRANCH//\//-}-${tag_suffix}-butterflynet-dev make docker-butterflynet-dev-push
   publish-docker-from-branch-dev:
     steps:
       - run:
@@ -84,6 +90,12 @@ commands:
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
             LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_BRANCH//\//-}-${tag_suffix}-calibnet-dev make docker-calibnet-dev-push
+      - run:
+          name: Publish Butterflynet Dev Docker Image to Docker Hub
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
+            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_BRANCH//\//-}-${tag_suffix}-butterflynet-dev make docker-butterflynet-dev-push
   publish-docker-semver-production:
     steps:
       - run:
@@ -104,6 +116,15 @@ commands:
             if [[ ! "$CIRCLE_TAG" =~ -rc[0-9]+$ ]]; then
               LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=calibnet-latest make docker-calibnet-push
             fi
+      - run:
+          name: Publish Butterflynet Production Semver Docker Image to Docker Hub
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_TAG//\//-}-butterfly make docker-butterfly-push
+            # omit release candidates from pushing butterfly-latest
+            if [[ ! "$CIRCLE_TAG" =~ -rc[0-9]+$ ]]; then
+              LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=butterfly-latest make docker-butterfly-push
+            fi
   publish-docker-semver-dev:
     steps:
       - run:
@@ -116,6 +137,11 @@ commands:
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_TAG//\//-}-calibnet-dev make docker-calibnet-dev-push
+      - run:
+          name: Publish Butterflynet Dev Semver Docker Image to Docker Hub
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_TAG//\//-}-butterflynet-dev make docker-butterflynet-dev-push
 
 jobs:
   publish-docker-from-branch:
@@ -136,7 +162,13 @@ jobs:
           version: "20.10.6"
       - publish-docker-semver-dev
       - publish-docker-semver-production
-  trigger-deployment:
+  # duplicated jobs are for making these jobs' descriptions
+  # in the pipelines within the CircleCI less confusing
+  trigger-tag-deployment:
+    executor: dockerizer
+    steps:
+      - trigger-deployment
+  trigger-branch-deployment:
     executor: dockerizer
     steps:
       - trigger-deployment
@@ -333,7 +365,7 @@ workflows:
               only: /^(master|main|deploy)$/
             tags:
               ignore: /.*/
-      - trigger-deployment:
+      - trigger-branch-deployment:
           requires:
             - publish-docker-from-branch
           filters:
@@ -350,7 +382,7 @@ workflows:
               ignore: /.*/
             tags:
               only: /^(v[0-9]+\.[0-9]+\.[0-9]+|.*dev.*)(-rc[0-9]+)*$/  # incl v0.0.0 or v0.0.0-rc0 or containing w `dev`
-      - trigger-deployment:
+      - trigger-tag-deployment:
           requires:
             - publish-docker-from-tag
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,20 +37,38 @@ commands:
       - run: git submodule update --init
   trigger-deployment:
     steps:
+      - checkout
       - run:
           name: Trigger deployment for filecoin-project/lily
           command: |
             # derive docker image deploy-tag according to the publish-* steps in this config
-            tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
-            deploy_branch=${CIRCLE_BRANCH}-$tag_suffix
-            deploy_target=${CIRCLE_TAG:-deploy_branch}
+            branch_tag_suffix=`echo "$CIRCLE_SHA1" | cut -c 1-8`
+            sanitized_branch=`echo $CIRCLE_BRANCH | sed 's:/:-:g'`
+            deploy_branch=${sanitized_branch}-${branch_tag_suffix}
+            sanitized_tag=`echo $CIRCLE_TAG | sed 's:/:-:g'`
+
+            # if $sanitized_tag is empty, default to $sanitized_branch
+            deploy_target=${sanitized_tag:-$deploy_branch}
+
+            # curlf fails with a non-zero exit code when the status code is not 2XX
+            curlf() {
+              OUTPUT_FILE=$(mktemp)
+              HTTP_CODE=$(curl --silent --output $OUTPUT_FILE --write-out "%{http_code}" "$@")
+              if [[ ${HTTP_CODE} -lt 200 || ${HTTP_CODE} -gt 299 ]] ; then
+                >&2 cat $OUTPUT_FILE && echo ""
+                return 22
+              fi
+              cat $OUTPUT_FILE
+              rm $OUTPUT_FILE
+            }
 
             # trigger deployment in sentinel-infra repo
-            curl --request POST \
+            curlf --request POST \
               --url https://circleci.com/api/v2/project/gh/filecoin-project/sentinel-infra/pipeline \
-              --header "Circle-Token: $SENTINEL_INFRA_CIRCLECI_API_TOKEN " \
+              --header "Circle-Token: $SENTINEL_INFRA_CIRCLECI_API_TOKEN" \
               --header "content-type: application/json" \
-              --data '{"branch":"master","parameters":{"trigger-deploy": true, "deploy-tag":"$deploy_target"}}'
+              --data "{\"branch\":\"master\",\"parameters\":{\"trigger-deploy\": true, \"deploy-tag\":\"$deploy_target\"}}"
+            echo ""
   validate-docker-executeable:
     steps:
       - run:
@@ -69,8 +87,9 @@ jobs:
           name: Publish Mainnet Production Docker Image from Lily branch to Docker Hub
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            sanitized_branch=`echo $CIRCLE_BRANCH | sed 's:/:-:g'`
             tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
-            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_BRANCH//\//-}-${tag_suffix} make docker-mainnet-push
+            make docker-mainnet-push LILY_IMAGE_TAG=${sanitized_branch}-${tag_suffix}
   publish-production-image-from-branch-for-calibnet:
     executor: dockerizer
     steps:
@@ -82,8 +101,9 @@ jobs:
           name: Publish Calibnet Production Docker Image from Lily branch to Docker Hub
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            sanitized_branch=`echo $CIRCLE_BRANCH | sed 's:/:-:g'`
             tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
-            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_BRANCH//\//-}-${tag_suffix}-calibnet make docker-calibnet-push
+            make docker-calibnet-push LILY_IMAGE_TAG=${sanitized_branch}-${tag_suffix}-calibnet
   publish-production-image-from-branch-for-butterflynet:
     executor: dockerizer
     steps:
@@ -95,8 +115,9 @@ jobs:
           name: Publish Butterflynet Production Docker Image from Lily branch to Docker Hub
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+            sanitized_branch=`echo $CIRCLE_BRANCH | sed 's:/:-:g'`
             tag_suffix=$(echo "$CIRCLE_SHA1" | cut -c 1-8)
-            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_BRANCH//\//-}-${tag_suffix}-butterflynet make docker-butterflynet-push
+            LILY_IMAGE_TAG=${sanitized_branch}-${tag_suffix}-butterflynet make docker-butterflynet-push
   publish-production-image-from-semver-tag-for-mainnet:
     executor: dockerizer
     steps:
@@ -108,10 +129,11 @@ jobs:
           name: Publish Mainnet Production Docker Image from Lily semver tag to Docker Hub
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_TAG//\//-} make docker-mainnet-push
+            sanitized_tag=`echo $CIRCLE_TAG | sed 's:/:-:g'`
+            LILY_IMAGE_TAG=$sanitized_tag make docker-mainnet-push
             # omit release candidates from pushing latest
             if [[ ! "$CIRCLE_TAG" =~ -rc[0-9]+$ ]]; then
-              LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=latest make docker-mainnet-push
+              LILY_IMAGE_TAG=latest make docker-mainnet-push
             fi
   publish-production-image-from-semver-tag-for-calibnet:
     executor: dockerizer
@@ -124,10 +146,11 @@ jobs:
           name: Publish Calibnet Production Docker Image from Lily semver tag to Docker Hub
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_TAG//\//-}-calibnet make docker-calibnet-push
+            sanitized_tag=`echo $CIRCLE_TAG | sed 's:/:-:g'`
+            LILY_IMAGE_TAG=$sanitized_tag make docker-calibnet-push
             # omit release candidates from pushing calibnet-latest
             if [[ ! "$CIRCLE_TAG" =~ -rc[0-9]+$ ]]; then
-              LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=calibnet-latest make docker-calibnet-push
+              LILY_IMAGE_TAG=calibnet-latest make docker-calibnet-push
             fi
   publish-production-image-from-semver-tag-for-butterflynet:
     executor: dockerizer
@@ -140,10 +163,11 @@ jobs:
           name: Publish Butterflynet Production Docker Image from Lily semver tag to Docker Hub
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=${CIRCLE_TAG//\//-}-butterfly make docker-butterfly-push
-            # omit release candidates from pushing butterfly-latest
+            sanitized_tag=`echo $CIRCLE_TAG | sed 's:/:-:g'`
+            LILY_IMAGE_TAG=$sanitized_tag-butterfly make docker-butterflynet-push
+            # omit release candidates from pushing butterflynet-latest
             if [[ ! "$CIRCLE_TAG" =~ -rc[0-9]+$ ]]; then
-              LILY_VERSION=$(git describe --always --tag --dirty) LILY_IMAGE_TAG=butterfly-latest make docker-butterfly-push
+              LILY_IMAGE_TAG=butterflynet-latest make docker-butterflynet-push
             fi
   # duplicated jobs are for making these jobs' descriptions
   # in the pipelines within the CircleCI less confusing

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,14 @@
 
 # ARG GO_BUILD_IMAGE is the image tag to use when building lily
 ARG GO_BUILD_IMAGE
+
 FROM $GO_BUILD_IMAGE AS builder
 
 # ARG LILY_NETWORK_TARGET determines which network the lily binary is built for.
 # Options: mainnet, nerpanet, calibnet, butterflynet, interopnet, 2k
 # See https://network.filecoin.io/ for more information about network_targets.
-ARG LILY_NETWORK_TARGET=mainnet
+ARG LILY_NETWORK_TARGET
+ENV LILY_NETWORK_TARGET=$LILY_NETWORK_TARGET
 
 RUN apt-get update
 RUN apt-get install -y \
@@ -26,6 +28,10 @@ COPY . /go/src/github.com/filecoin-project/lily
 
 RUN make deps
 RUN go mod download
+
+# ARG LILY_VERSION will set the binary version upon build
+ARG LILY_VERSION
+ENV LILY_VERSION=$LILY_VERSION
 RUN make $LILY_NETWORK_TARGET
 RUN cp ./lily /usr/bin/
 
@@ -33,7 +39,7 @@ RUN cp ./lily /usr/bin/
 # partial for producing a minimal image by extracting the binary
 # from a prior build step (builder.tpl)
 
-FROM buildpack-deps:buster-curl
+FROM buildpack-deps:bookworm-curl
 COPY --from=builder /go/src/github.com/filecoin-project/lily/lily /usr/bin/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libOpenCL.so* /lib/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libhwloc.so* /lib/

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -6,12 +6,14 @@
 
 # ARG GO_BUILD_IMAGE is the image tag to use when building lily
 ARG GO_BUILD_IMAGE
+
 FROM $GO_BUILD_IMAGE AS builder
 
 # ARG LILY_NETWORK_TARGET determines which network the lily binary is built for.
 # Options: mainnet, nerpanet, calibnet, butterflynet, interopnet, 2k
 # See https://network.filecoin.io/ for more information about network_targets.
-ARG LILY_NETWORK_TARGET=mainnet
+ARG LILY_NETWORK_TARGET
+ENV LILY_NETWORK_TARGET=$LILY_NETWORK_TARGET
 
 RUN apt-get update
 RUN apt-get install -y \
@@ -26,6 +28,10 @@ COPY . /go/src/github.com/filecoin-project/lily
 
 RUN make deps
 RUN go mod download
+
+# ARG LILY_VERSION will set the binary version upon build
+ARG LILY_VERSION
+ENV LILY_VERSION=$LILY_VERSION
 RUN make $LILY_NETWORK_TARGET
 RUN cp ./lily /usr/bin/
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ LILY_IMAGE_NAME?=filecoin/lily
 # LILY_VERSION is the nearest tag plus number of commits and short form of
 # most recent commit since the tag, if any. It may be overriden by the environment.
 LILY_VERSION?=$(shell git describe --always --tag --dirty)
+docker_sanitized_lily_version=$(shell echo ${LILY_VERSION} | sed 's:/:-:g')
 
 unexport GOFLAGS
 
@@ -176,7 +177,7 @@ CLEAN+=Dockerfile.dev
 .PHONY: docker-mainnet
 docker-mainnet: LILY_DOCKER_FILE ?= Dockerfile
 docker-mainnet: LILY_NETWORK_TARGET ?= mainnet
-docker-mainnet: LILY_IMAGE_TAG ?= $(LILY_VERSION)
+docker-mainnet: LILY_IMAGE_TAG ?= $(docker_sanitized_lily_version)
 docker-mainnet: docker-build-image-template
 
 .PHONY: docker-mainnet-push
@@ -185,7 +186,7 @@ docker-mainnet-push: docker-mainnet docker-tag-and-push-template
 .PHONY: docker-mainnet-dev
 docker-mainnet-dev: LILY_DOCKER_FILE ?= Dockerfile.dev
 docker-mainnet-dev: LILY_NETWORK_TARGET ?= mainnet
-docker-mainnet-dev: LILY_IMAGE_TAG ?= $(LILY_VERSION)-dev
+docker-mainnet-dev: LILY_IMAGE_TAG ?= $(docker_sanitized_lily_version)-dev
 docker-mainnet-dev: docker-build-image-template
 
 .PHONY: docker-mainnet-dev-push
@@ -195,7 +196,7 @@ docker-mainnet-dev-push: docker-mainnet-dev docker-tag-and-push-template
 .PHONY: docker-calibnet
 docker-calibnet: LILY_DOCKER_FILE ?= Dockerfile
 docker-calibnet: LILY_NETWORK_TARGET ?= calibnet
-docker-calibnet: LILY_IMAGE_TAG ?= $(LILY_VERSION)-calibnet
+docker-calibnet: LILY_IMAGE_TAG ?= $(docker_sanitized_lily_version)-calibnet
 docker-calibnet: docker-build-image-template
 
 .PHONY: docker-calibnet-push
@@ -204,7 +205,7 @@ docker-calibnet-push: docker-calibnet docker-tag-and-push-template
 .PHONY: docker-calibnet-dev
 docker-calibnet-dev: LILY_DOCKER_FILE ?= Dockerfile.dev
 docker-calibnet-dev: LILY_NETWORK_TARGET ?= calibnet
-docker-calibnet-dev: LILY_IMAGE_TAG ?= $(LILY_VERSION)-calibnet-dev
+docker-calibnet-dev: LILY_IMAGE_TAG ?= $(docker_sanitized_lily_version)-calibnet-dev
 docker-calibnet-dev: docker-build-image-template
 
 .PHONY: docker-calibnet-dev-push
@@ -214,7 +215,7 @@ docker-calibnet-dev-push: docker-calibnet-dev docker-tag-and-push-template
 .PHONY: docker-interopnet
 docker-interopnet: LILY_DOCKER_FILE ?= Dockerfile
 docker-interopnet: LILY_NETWORK_TARGET ?= interopnet
-docker-interopnet: LILY_IMAGE_TAG ?= $(LILY_VERSION)-interopnet
+docker-interopnet: LILY_IMAGE_TAG ?= $(docker_sanitized_lily_version)-interopnet
 docker-interopnet: docker-build-image-template
 
 .PHONY: docker-interopnet-push
@@ -223,7 +224,7 @@ docker-interopnet-push: docker-interopnet docker-tag-and-push-template
 .PHONY: docker-interopnet-dev
 docker-interopnet-dev: LILY_DOCKER_FILE ?= Dockerfile.dev
 docker-interopnet-dev: LILY_NETWORK_TARGET ?= interopnet
-docker-interopnet-dev: LILY_IMAGE_TAG ?= $(LILY_VERSION)-interopnet-dev
+docker-interopnet-dev: LILY_IMAGE_TAG ?= $(docker_sanitized_lily_version)-interopnet-dev
 docker-interopnet-dev: docker-build-image-template
 
 .PHONY: docker-interopnet-dev-push
@@ -233,7 +234,7 @@ docker-interopnet-dev-push: docker-interopnet-dev docker-tag-and-push-template
 .PHONY: docker-butterflynet
 docker-butterflynet: LILY_DOCKER_FILE ?= Dockerfile
 docker-butterflynet: LILY_NETWORK_TARGET ?= butterflynet
-docker-butterflynet: LILY_IMAGE_TAG ?= $(LILY_VERSION)-butterflynet
+docker-butterflynet: LILY_IMAGE_TAG ?= $(docker_sanitized_lily_version)-butterflynet
 docker-butterflynet: docker-build-image-template
 
 .PHONY: docker-butterflynet-push
@@ -242,7 +243,7 @@ docker-butterflynet-push: docker-butterflynet docker-tag-and-push-template
 .PHONY: docker-butterflynet-dev
 docker-butterflynet-dev: LILY_DOCKER_FILE ?= Dockerfile.dev
 docker-butterflynet-dev: LILY_NETWORK_TARGET ?= butterflynet
-docker-butterflynet-dev: LILY_IMAGE_TAG ?= $(LILY_VERSION)-butterflynet-dev
+docker-butterflynet-dev: LILY_IMAGE_TAG ?= $(docker_sanitized_lily_version)-butterflynet-dev
 docker-butterflynet-dev: docker-build-image-template
 
 .PHONY: docker-butterflynet-dev-push
@@ -252,7 +253,7 @@ docker-butterflynet-dev-push: docker-butterflynet-dev docker-tag-and-push-templa
 .PHONY: docker-nerpanet
 docker-nerpanet: LILY_DOCKER_FILE ?= Dockerfile
 docker-nerpanet: LILY_NETWORK_TARGET ?= nerpanet
-docker-nerpanet: LILY_IMAGE_TAG ?= $(LILY_VERSION)-nerpanet
+docker-nerpanet: LILY_IMAGE_TAG ?= $(docker_sanitized_lily_version)-nerpanet
 docker-nerpanet: docker-build-image-template
 
 .PHONY: docker-nerpanet-push
@@ -261,7 +262,7 @@ docker-nerpanet-push: docker-nerpanet docker-tag-and-push-template
 .PHONY: docker-nerpanet-dev
 docker-nerpanet-dev: LILY_DOCKER_FILE ?= Dockerfile.dev
 docker-nerpanet-dev: LILY_NETWORK_TARGET ?= nerpanet
-docker-nerpanet-dev: LILY_IMAGE_TAG ?= $(LILY_VERSION)-nerpanet-dev
+docker-nerpanet-dev: LILY_IMAGE_TAG ?= $(docker_sanitized_lily_version)-nerpanet-dev
 docker-nerpanet-dev: docker-build-image-template
 
 .PHONY: docker-nerpanet-dev-push
@@ -271,7 +272,7 @@ docker-nerpanet-dev-push: docker-nerpanet-dev docker-tag-and-push-template
 .PHONY: docker-2k
 docker-2k: LILY_DOCKER_FILE ?= Dockerfile
 docker-2k: LILY_NETWORK_TARGET ?= 2k
-docker-2k: LILY_IMAGE_TAG ?= $(LILY_VERSION)-2k
+docker-2k: LILY_IMAGE_TAG ?= $(docker_sanitized_lily_version)-2k
 docker-2k: docker-build-image-template
 
 .PHONY: docker-2k-push
@@ -280,7 +281,7 @@ docker-2k-push: docker-2k docker-tag-and-push-template
 .PHONY: docker-2k-dev
 docker-2k-dev: LILY_DOCKER_FILE ?= Dockerfile.dev
 docker-2k-dev: LILY_NETWORK_TARGET ?= 2k
-docker-2k-dev: LILY_IMAGE_TAG ?= $(LILY_VERSION)-2k-dev
+docker-2k-dev: LILY_IMAGE_TAG ?= $(docker_sanitized_lily_version)-2k-dev
 docker-2k-dev: docker-build-image-template
 
 .PHONY: docker-2k-dev-push

--- a/build/docker/builder.tpl
+++ b/build/docker/builder.tpl
@@ -4,12 +4,13 @@
 # ARG GO_BUILD_IMAGE is the image tag to use when building lily
 ARG GO_BUILD_IMAGE
 
+FROM $GO_BUILD_IMAGE AS builder
+
 # ARG LILY_NETWORK_TARGET determines which network the lily binary is built for.
 # Options: mainnet, nerpanet, calibnet, butterflynet, interopnet, 2k
 # See https://network.filecoin.io/ for more information about network_targets.
 ARG LILY_NETWORK_TARGET
-
-FROM $GO_BUILD_IMAGE AS builder
+ENV LILY_NETWORK_TARGET=$LILY_NETWORK_TARGET
 
 RUN apt-get update
 RUN apt-get install -y \
@@ -28,7 +29,6 @@ RUN go mod download
 # ARG LILY_VERSION will set the binary version upon build
 ARG LILY_VERSION
 ENV LILY_VERSION=$LILY_VERSION
-
 RUN make $LILY_NETWORK_TARGET
 RUN cp ./lily /usr/bin/
 


### PR DESCRIPTION
This PR enables continuous delivery triggers into our infrastructure repos. There are a few changes included:
- separate docker image publishing into parallel jobs
- fix calibnet and butterflynet docker builds
- docker image builds trigger on
  - tags containing `dev`
  - branch names containing `deploy`
- include job which triggers the pipeline in the infra repo. Deployments trigger on
  - tags containing `dev`
  - branch names containing `deploy`