### PR TITLE
Set default log level to info. Resolves #703

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func main() {
 			&cli.StringFlag{
 				Name:        "log-level",
 				EnvVars:     []string{"GOLOG_LOG_LEVEL"},
-				Value:       "debug",
+				Value:       "info",
 				Usage:       "Set the default log level for all loggers to `LEVEL`",
 				Destination: &commands.VisorLogFlags.LogLevel,
 			},


### PR DESCRIPTION
This PR sets the default log level to `info` instead of `debug`.

Resolves #703 