### PR TITLE
feat: set log level with regular expression

### DIFF
--- a/lens/lily/api.go
+++ b/lens/lily/api.go
@@ -51,8 +51,9 @@ type LilyAPI interface {
 	Shutdown(context.Context) error
 
 	// LogList returns a list of loggers
-	LogList(context.Context) ([]string, error)         //perm:write
-	LogSetLevel(context.Context, string, string) error //perm:write
+	LogList(context.Context) ([]string, error)                       //perm:write
+	LogSetLevel(context.Context, string, string) error               //perm:write
+	LogSetLevelRegex(ctx context.Context, regex, level string) error //perm:write
 
 	// ID returns peerID of libp2p node backing this API
 	ID(context.Context) (peer.ID, error) //perm:read

--- a/lens/lily/impl.go
+++ b/lens/lily/impl.go
@@ -348,6 +348,10 @@ func (m *LilyNodeAPI) LogSetLevel(ctx context.Context, subsystem, level string) 
 	return logging.SetLogLevel(subsystem, level)
 }
 
+func (m *LilyNodeAPI) LogSetLevelRegex(ctx context.Context, regex, level string) error {
+	return logging.SetLogLevelRegex(regex, level)
+}
+
 func (m *LilyNodeAPI) Shutdown(ctx context.Context) error {
 	m.ShutdownChan <- struct{}{}
 	return nil

--- a/lens/lily/struct.go
+++ b/lens/lily/struct.go
@@ -58,8 +58,9 @@ type LilyAPIStruct struct {
 		ChainSetHead              func(context.Context, types.TipSetKey) error                                  `perm:"read"`
 		ChainGetGenesis           func(context.Context) (*types.TipSet, error)                                  `perm:"read"`
 
-		LogList     func(context.Context) ([]string, error)     `perm:"read"`
-		LogSetLevel func(context.Context, string, string) error `perm:"read"`
+		LogList          func(context.Context) ([]string, error)     `perm:"read"`
+		LogSetLevel      func(context.Context, string, string) error `perm:"read"`
+		LogSetLevelRegex func(context.Context, string, string) error `perm:"read"`
 
 		ID               func(context.Context) (peer.ID, error)                        `perm:"read"`
 		NetAutoNatStatus func(context.Context) (api.NatInfo, error)                    `perm:"read"`
@@ -181,6 +182,10 @@ func (s *LilyAPIStruct) LogList(ctx context.Context) ([]string, error) {
 
 func (s *LilyAPIStruct) LogSetLevel(ctx context.Context, subsystem, level string) error {
 	return s.Internal.LogSetLevel(ctx, subsystem, level)
+}
+
+func (s *LilyAPIStruct) LogSetLevelRegex(ctx context.Context, regex, level string) error {
+	return s.Internal.LogSetLevelRegex(ctx, regex, level)
 }
 
 func (s *LilyAPIStruct) NetAutoNatStatus(ctx context.Context) (api.NatInfo, error) {


### PR DESCRIPTION
lets you do things like:
`lily log set-level error` // set all loggers to error level
`lily log set-level-regex info 'lily/*'` // set all lily loggers (since we follow the `lily/<logname>` convention) to info