### PR TITLE
fix: persisting miner task results with nil models

### DIFF
--- a/model/actors/miner/task.go
+++ b/model/actors/miner/task.go
@@ -1,0 +1,75 @@
+package miner
+
+import (
+	"context"
+
+	"github.com/filecoin-project/lily/model"
+)
+
+type MinerTaskResult struct {
+	Posts MinerSectorPostList
+
+	MinerInfoModel           *MinerInfo
+	FeeDebtModel             *MinerFeeDebt
+	LockedFundsModel         *MinerLockedFund
+	CurrentDeadlineInfoModel *MinerCurrentDeadlineInfo
+	PreCommitsModel          MinerPreCommitInfoList
+	SectorsModelV1_6         MinerSectorInfoV1_6List
+	SectorsModelV7           MinerSectorInfoV7List
+	SectorEventsModel        MinerSectorEventList
+	SectorDealsModel         MinerSectorDealList
+}
+
+func (res *MinerTaskResult) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
+	if res.PreCommitsModel != nil {
+		if err := res.PreCommitsModel.Persist(ctx, s, version); err != nil {
+			return err
+		}
+	}
+	if res.SectorsModelV1_6 != nil {
+		if err := res.SectorsModelV1_6.Persist(ctx, s, version); err != nil {
+			return err
+		}
+	}
+	if res.SectorsModelV7 != nil {
+		if err := res.SectorsModelV7.Persist(ctx, s, version); err != nil {
+			return err
+		}
+	}
+	if len(res.SectorEventsModel) > 0 {
+		if err := res.SectorEventsModel.Persist(ctx, s, version); err != nil {
+			return err
+		}
+	}
+	if res.MinerInfoModel != nil {
+		if err := res.MinerInfoModel.Persist(ctx, s, version); err != nil {
+			return err
+		}
+	}
+	if res.LockedFundsModel != nil {
+		if err := res.LockedFundsModel.Persist(ctx, s, version); err != nil {
+			return err
+		}
+	}
+	if res.FeeDebtModel != nil {
+		if err := res.FeeDebtModel.Persist(ctx, s, version); err != nil {
+			return err
+		}
+	}
+	if res.CurrentDeadlineInfoModel != nil {
+		if err := res.CurrentDeadlineInfoModel.Persist(ctx, s, version); err != nil {
+			return err
+		}
+	}
+	if res.SectorDealsModel != nil {
+		if err := res.SectorDealsModel.Persist(ctx, s, version); err != nil {
+			return err
+		}
+	}
+	if res.Posts != nil {
+		if err := res.Posts.Persist(ctx, s, version); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/tasks/actorstate/miner.go
+++ b/tasks/actorstate/miner.go
@@ -84,15 +84,16 @@ func (m StorageMinerExtractor) Extract(ctx context.Context, a ActorInfo, emsgs [
 		return nil, xerrors.Errorf("extracting miner posts: %v", err)
 	}
 
-	out := model.PersistableList{
-		minerInfoModel,
-		lockedFundsModel,
-		feeDebtModel,
-		currDeadlineModel,
-		preCommitModel,
-		sectorDealsModel,
-		sectorEventsModel,
-		posts,
+	// a wrapper type used to avoid calling persist on nil models
+	out := &minermodel.MinerTaskResult{
+		Posts:                    posts,
+		MinerInfoModel:           minerInfoModel,
+		FeeDebtModel:             feeDebtModel,
+		LockedFundsModel:         lockedFundsModel,
+		CurrentDeadlineInfoModel: currDeadlineModel,
+		PreCommitsModel:          preCommitModel,
+		SectorEventsModel:        sectorEventsModel,
+		SectorDealsModel:         sectorDealsModel,
 	}
 
 	// if the miner actor is v1-6 persist its model to the miner_sector_infos table
@@ -119,10 +120,10 @@ func (m StorageMinerExtractor) Extract(ctx context.Context, a ActorInfo, emsgs [
 				ExpectedStoragePledge: sm.ExpectedStoragePledge,
 			})
 		}
-		out = append(out, sectorModelV6Minus)
+		out.SectorsModelV1_6 = sectorModelV6Minus
 	} else {
 		// if the miner actor is v7 or newer persist its model the miner_sector_infos_v7 table
-		out = append(out, sectorModelV7)
+		out.SectorsModelV7 = sectorModelV7
 	}
 
 	return out, nil


### PR DESCRIPTION
This change is required to prevent nil models from the `actorstatesminer` task from being persisted, e.g.:
```
{"level":"error","ts":"2022-02-25T20:45:10.165Z","logger":"lily/chain","caller":"chain/indexer.go:506","msg":"persistence failed","current":725047,"next":725048,"task":"actorstatesminer","error":"persisting model: pg: Model(nil)","errorVerbose":"persisting model:\n    github.com/filecoin-project/lily/storage.(*TxStorage).PersistModel\n        /go/src/github.com/filecoin-project/lily/storage/sql.go:428\n  - pg: Model(nil)"}
```
was found in calibnet staging