### PR TITLE
fix: wrong use of fallthrough in marshalling paramWrapperType

### DIFF
--- a/lens/util/repo.go
+++ b/lens/util/repo.go
@@ -380,13 +380,13 @@ func (wt *paramWrapperType) MarshalJSON() ([]byte, error) {
 		return json.Marshal(wt.obj)
 	}
 
-	switch t.Kind() {
-	case reflect.Ptr:
+	if t.Kind() == reflect.Ptr {
 		// unwrap pointer
 		v = v.Elem()
 		t = t.Elem()
-		fallthrough
+	}
 
+	switch t.Kind() {
 	case reflect.Struct:
 		// if its a struct, walk its fields and recurse.
 		m := make(map[string]interface{})


### PR DESCRIPTION
```go
	switch t.Kind() {
	case reflect.Ptr:
		// unwrap pointer
		v = v.Elem()
		t = t.Elem()
		fallthrough

	case reflect.Struct:
		// if its a struct, walk its fields and recurse.
...
```

Fallthrough will execute the action in next case regardless of the condition.
`case reflect.Struct` will be executed even if the pointee of a pointer is not a Struct.

```go
package main

import (
	"fmt"
)

func main() {
	eval := func() int {
		fmt.Println("eval")
		return 2
	}
	switch {
	case 1 == 1:
		fmt.Println("1 == 1")
		fallthrough
	case eval() == 1:
		fmt.Println("2 == 1")
	}
}
````
Output:
```
1 == 1
2 == 1
```
[Go Playground](https://go.dev/play/p/t_RbGHPCnd7)

