### PR TITLE
chore: Dockerfiles are no longer included in `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,9 @@ mainnet: build
 
 # Dockerfiles
 
+docker-clean:
+	rm Dockerfile Dockerfile.dev
+
 docker-files: Dockerfile Dockerfile.dev
 
 Dockerfile:
@@ -161,7 +164,6 @@ Dockerfile:
 		build/docker/builder.tpl \
 		build/docker/prod_entrypoint.tpl \
 		> ./Dockerfile
-CLEAN+=Dockerfile
 
 Dockerfile.dev:
 	@echo "Writing ./Dockerfile.dev..."
@@ -169,7 +171,6 @@ Dockerfile.dev:
 		build/docker/builder.tpl \
 		build/docker/dev_entrypoint.tpl \
 		> ./Dockerfile.dev
-CLEAN+=Dockerfile.dev
 
 # Docker images
 


### PR DESCRIPTION
Cleaning Dockerfiles now have their own make target `make docker-clean` and are no longer included in `make clean`.