### PR TITLE
fix: loading miner actor when actor doesn't exist

### DIFF
--- a/chain/actors/builtin/miner/diff.go
+++ b/chain/actors/builtin/miner/diff.go
@@ -80,9 +80,25 @@ func DiffPreCommits(ctx context.Context, store adt.Store, pre, cur State) (*PreC
 	return diffContainer.Results, nil
 }
 
+func MakeSectorChanges() *SectorChanges {
+	var out *SectorChanges
+	out.Added = []SectorOnChainInfo{}
+	out.Removed = []SectorOnChainInfo{}
+	out.Snapped = []SectorModification{}
+	out.Extended = []SectorModification{}
+	return out
+}
+
+func MakePreCommitChanges() *PreCommitChanges {
+	var out *PreCommitChanges
+	out.Added = []SectorPreCommitOnChainInfo{}
+	out.Removed = []SectorPreCommitOnChainInfo{}
+	return out
+}
+
 func NewPreCommitDiffContainer(pre, cur State) *preCommitDiffContainer {
 	return &preCommitDiffContainer{
-		Results: new(PreCommitChanges),
+		Results: MakePreCommitChanges(),
 		pre:     pre,
 		after:   cur,
 	}
@@ -179,7 +195,7 @@ func DiffSectors(ctx context.Context, store adt.Store, pre, cur State) (*SectorC
 
 func NewSectorDiffContainer(pre, cur State) *sectorDiffContainer {
 	return &sectorDiffContainer{
-		Results: new(SectorChanges),
+		Results: MakeSectorChanges(),
 		pre:     pre,
 		after:   cur,
 	}

--- a/tasks/actorstate/miner/sector.go
+++ b/tasks/actorstate/miner/sector.go
@@ -7,6 +7,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/lily/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lily/model"
 	minermodel "github.com/filecoin-project/lily/model/actors/miner"
 	"github.com/filecoin-project/lily/tasks/actorstate"
@@ -27,48 +28,43 @@ func (SectorInfoExtractor) Extract(ctx context.Context, a actorstate.ActorInfo, 
 		return nil, xerrors.Errorf("creating miner state extraction context: %w", err)
 	}
 
-	sectorChanges, err := node.DiffSectors(ctx, a.Address, a.Current, a.Executed, ec.PrevState, ec.CurrState)
-	if err != nil {
-		return nil, err
+	var sectors []*miner.SectorOnChainInfo
+	if !ec.HasPreviousState() {
+		// If the miner doesn't have previous state list all of its current sectors.
+		sectors, err = ec.CurrState.LoadSectors(nil)
+		if err != nil {
+			return nil, xerrors.Errorf("loading miner sectors: %w", err)
+		}
+	} else {
+		// If the miner has previous state compute the list of sectors added in its new state.
+		sectorChanges, err := node.DiffSectors(ctx, a.Address, a.Current, a.Executed, ec.PrevState, ec.CurrState)
+		if err != nil {
+			return nil, err
+		}
+		for _, sector := range sectorChanges.Added {
+			sectors = append(sectors, &sector)
+		}
+		for _, sector := range sectorChanges.Extended {
+			sectors = append(sectors, &sector.To)
+		}
 	}
 
-	// transform sector changes to a model
-	sectorModel := minermodel.MinerSectorInfoV1_6List{}
-	for _, added := range sectorChanges.Added {
-		sm := &minermodel.MinerSectorInfoV1_6{
-			Height:                int64(ec.CurrTs.Height()),
+	sectorModel := make(minermodel.MinerSectorInfoV1_6List, len(sectors))
+	for i, sector := range sectors {
+		sectorModel[i] = &minermodel.MinerSectorInfoV1_6{
+			Height:                int64(a.Current.Height()),
 			MinerID:               a.Address.String(),
-			SectorID:              uint64(added.SectorNumber),
 			StateRoot:             a.Current.ParentState().String(),
-			SealedCID:             added.SealedCID.String(),
-			ActivationEpoch:       int64(added.Activation),
-			ExpirationEpoch:       int64(added.Expiration),
-			DealWeight:            added.DealWeight.String(),
-			VerifiedDealWeight:    added.VerifiedDealWeight.String(),
-			InitialPledge:         added.InitialPledge.String(),
-			ExpectedDayReward:     added.ExpectedDayReward.String(),
-			ExpectedStoragePledge: added.ExpectedStoragePledge.String(),
+			SectorID:              uint64(sector.SectorNumber),
+			SealedCID:             sector.SealedCID.String(),
+			ActivationEpoch:       int64(sector.Activation),
+			ExpirationEpoch:       int64(sector.Expiration),
+			DealWeight:            sector.DealWeight.String(),
+			VerifiedDealWeight:    sector.VerifiedDealWeight.String(),
+			InitialPledge:         sector.InitialPledge.String(),
+			ExpectedDayReward:     sector.ExpectedDayReward.String(),
+			ExpectedStoragePledge: sector.ExpectedStoragePledge.String(),
 		}
-		sectorModel = append(sectorModel, sm)
-	}
-
-	// do the same for extended sectors, since they have a new deadline
-	for _, extended := range sectorChanges.Extended {
-		sm := &minermodel.MinerSectorInfoV1_6{
-			Height:                int64(ec.CurrTs.Height()),
-			MinerID:               a.Address.String(),
-			SectorID:              uint64(extended.To.SectorNumber),
-			StateRoot:             a.Current.ParentState().String(),
-			SealedCID:             extended.To.SealedCID.String(),
-			ActivationEpoch:       int64(extended.To.Activation),
-			ExpirationEpoch:       int64(extended.To.Expiration),
-			DealWeight:            extended.To.DealWeight.String(),
-			VerifiedDealWeight:    extended.To.VerifiedDealWeight.String(),
-			InitialPledge:         extended.To.InitialPledge.String(),
-			ExpectedDayReward:     extended.To.ExpectedDayReward.String(),
-			ExpectedStoragePledge: extended.To.ExpectedStoragePledge.String(),
-		}
-		sectorModel = append(sectorModel, sm)
 	}
 
 	return sectorModel, nil

--- a/tasks/actorstate/miner/sector_deals.go
+++ b/tasks/actorstate/miner/sector_deals.go
@@ -7,6 +7,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/lily/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lily/model"
 	minermodel "github.com/filecoin-project/lily/model/actors/miner"
 	"github.com/filecoin-project/lily/tasks/actorstate"
@@ -27,18 +28,36 @@ func (SectorDealsExtractor) Extract(ctx context.Context, a actorstate.ActorInfo,
 		return nil, xerrors.Errorf("creating miner state extraction context: %w", err)
 	}
 
-	sectorDealsModel := minermodel.MinerSectorDealList{}
-	sectorChanges, err := node.DiffSectors(ctx, a.Address, a.Current, a.Executed, ec.PrevState, ec.CurrState)
-	if err != nil {
-		return nil, err
+	var sectors []*miner.SectorOnChainInfo
+	if !ec.HasPreviousState() {
+		// If the miner doesn't have previous state list all of its current sectors.
+		sectors, err = ec.CurrState.LoadSectors(nil)
+		if err != nil {
+			return nil, xerrors.Errorf("loading miner sectors: %w", err)
+		}
+	} else {
+		// If the miner has previous state compute the list of new sectors in its current state.
+		sectorChanges, err := node.DiffSectors(ctx, a.Address, a.Current, a.Executed, ec.PrevState, ec.CurrState)
+		if err != nil {
+			return nil, err
+		}
+		// sectors that were added _may_ contain dealIDs'
+		for _, sector := range sectorChanges.Added {
+			sectors = append(sectors, &sector)
+		}
+		// sectors that were snapped _will_ contain dealID's per: https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0019.md#spec
+		for _, sector := range sectorChanges.Snapped {
+			sectors = append(sectors, &sector.To)
+		}
 	}
 
-	for _, newSector := range sectorChanges.Added {
-		for _, dealID := range newSector.DealIDs {
+	sectorDealsModel := minermodel.MinerSectorDealList{}
+	for _, sector := range sectors {
+		for _, dealID := range sector.DealIDs {
 			sectorDealsModel = append(sectorDealsModel, &minermodel.MinerSectorDeal{
 				Height:   int64(ec.CurrTs.Height()),
 				MinerID:  a.Address.String(),
-				SectorID: uint64(newSector.SectorNumber),
+				SectorID: uint64(sector.SectorNumber),
 				DealID:   uint64(dealID),
 			})
 		}

--- a/tasks/actorstate/miner/sectorv7.go
+++ b/tasks/actorstate/miner/sectorv7.go
@@ -7,6 +7,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/lily/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lily/model"
 	minermodel "github.com/filecoin-project/lily/model/actors/miner"
 	"github.com/filecoin-project/lily/tasks/actorstate"
@@ -27,81 +28,50 @@ func (V7SectorInfoExtractor) Extract(ctx context.Context, a actorstate.ActorInfo
 		return nil, xerrors.Errorf("creating miner state extraction context: %w", err)
 	}
 
-	sectorChanges, err := node.DiffSectors(ctx, a.Address, a.Current, a.Executed, ec.PrevState, ec.CurrState)
-	if err != nil {
-		return nil, err
-	}
-
-	// transform sector changes to a model
-	sectorModel := minermodel.MinerSectorInfoV7List{}
-	for _, added := range sectorChanges.Added {
-		sectorKeyCID := ""
-		if added.SectorKeyCID != nil {
-			sectorKeyCID = added.SectorKeyCID.String()
+	var sectors []*miner.SectorOnChainInfo
+	if !ec.HasPreviousState() {
+		// If the miner doesn't have previous state list all of its current sectors.
+		sectors, err = ec.CurrState.LoadSectors(nil)
+		if err != nil {
+			return nil, xerrors.Errorf("loading miner sectors: %w", err)
 		}
-		sm := &minermodel.MinerSectorInfoV7{
-			Height:                int64(ec.CurrTs.Height()),
+	} else {
+		// If the miner has previous state compute the list of new sectors in its current state.
+		sectorChanges, err := node.DiffSectors(ctx, a.Address, a.Current, a.Executed, ec.PrevState, ec.CurrState)
+		if err != nil {
+			return nil, err
+		}
+		for _, sector := range sectorChanges.Added {
+			sectors = append(sectors, &sector)
+		}
+		for _, sector := range sectorChanges.Extended {
+			sectors = append(sectors, &sector.To)
+		}
+		for _, sector := range sectorChanges.Snapped {
+			sectors = append(sectors, &sector.To)
+		}
+	}
+	sectorModel := make(minermodel.MinerSectorInfoV7List, len(sectors))
+	for i, sector := range sectors {
+		sectorKeyCID := ""
+		if sector.SectorKeyCID != nil {
+			sectorKeyCID = sector.SectorKeyCID.String()
+		}
+		sectorModel[i] = &minermodel.MinerSectorInfoV7{
+			Height:                int64(a.Current.Height()),
 			MinerID:               a.Address.String(),
-			SectorID:              uint64(added.SectorNumber),
 			StateRoot:             a.Current.ParentState().String(),
-			SealedCID:             added.SealedCID.String(),
-			ActivationEpoch:       int64(added.Activation),
-			ExpirationEpoch:       int64(added.Expiration),
-			DealWeight:            added.DealWeight.String(),
-			VerifiedDealWeight:    added.VerifiedDealWeight.String(),
-			InitialPledge:         added.InitialPledge.String(),
-			ExpectedDayReward:     added.ExpectedDayReward.String(),
-			ExpectedStoragePledge: added.ExpectedStoragePledge.String(),
+			SectorID:              uint64(sector.SectorNumber),
+			SealedCID:             sector.SealedCID.String(),
+			ActivationEpoch:       int64(sector.Activation),
+			ExpirationEpoch:       int64(sector.Expiration),
+			DealWeight:            sector.DealWeight.String(),
+			VerifiedDealWeight:    sector.VerifiedDealWeight.String(),
+			InitialPledge:         sector.InitialPledge.String(),
+			ExpectedDayReward:     sector.ExpectedDayReward.String(),
+			ExpectedStoragePledge: sector.ExpectedStoragePledge.String(),
 			SectorKeyCID:          sectorKeyCID,
 		}
-		sectorModel = append(sectorModel, sm)
-	}
-
-	// do the same for extended sectors, since they have a new deadline
-	for _, extended := range sectorChanges.Extended {
-		sectorKeyCID := ""
-		if extended.To.SectorKeyCID != nil {
-			sectorKeyCID = extended.To.SectorKeyCID.String()
-		}
-		sm := &minermodel.MinerSectorInfoV7{
-			Height:                int64(ec.CurrTs.Height()),
-			MinerID:               a.Address.String(),
-			SectorID:              uint64(extended.To.SectorNumber),
-			StateRoot:             a.Current.ParentState().String(),
-			SealedCID:             extended.To.SealedCID.String(),
-			ActivationEpoch:       int64(extended.To.Activation),
-			ExpirationEpoch:       int64(extended.To.Expiration),
-			DealWeight:            extended.To.DealWeight.String(),
-			VerifiedDealWeight:    extended.To.VerifiedDealWeight.String(),
-			InitialPledge:         extended.To.InitialPledge.String(),
-			ExpectedDayReward:     extended.To.ExpectedDayReward.String(),
-			ExpectedStoragePledge: extended.To.ExpectedStoragePledge.String(),
-			SectorKeyCID:          sectorKeyCID,
-		}
-		sectorModel = append(sectorModel, sm)
-	}
-
-	for _, snapped := range sectorChanges.Snapped {
-		sectorKeyCID := ""
-		if snapped.To.SectorKeyCID != nil {
-			sectorKeyCID = snapped.To.SectorKeyCID.String()
-		}
-		sm := &minermodel.MinerSectorInfoV7{
-			Height:                int64(ec.CurrTs.Height()),
-			MinerID:               a.Address.String(),
-			SectorID:              uint64(snapped.To.SectorNumber),
-			StateRoot:             a.Current.ParentState().String(),
-			SealedCID:             snapped.To.SealedCID.String(),
-			ActivationEpoch:       int64(snapped.To.Activation),
-			ExpirationEpoch:       int64(snapped.To.Expiration),
-			DealWeight:            snapped.To.DealWeight.String(),
-			VerifiedDealWeight:    snapped.To.VerifiedDealWeight.String(),
-			InitialPledge:         snapped.To.InitialPledge.String(),
-			ExpectedDayReward:     snapped.To.ExpectedDayReward.String(),
-			ExpectedStoragePledge: snapped.To.ExpectedStoragePledge.String(),
-			SectorKeyCID:          sectorKeyCID,
-		}
-		sectorModel = append(sectorModel, sm)
 	}
 
 	return sectorModel, nil


### PR DESCRIPTION
Note: This PR targets indexer-refactor branch
- fixes #897
- simply miner extractor logic
- ensure snapped sector dealID's are recorded by SectorDealsExtractor