### PR TITLE
fix: prevent lily from running with incompatible schema

### DIFF
--- a/storage/sql.go
+++ b/storage/sql.go
@@ -92,7 +92,7 @@ var (
 
 var (
 	ErrSchemaTooOld = errors.New("database schema is too old and requires migration")
-	ErrSchemaTooNew = errors.New("database schema is too new for this version of visor")
+	ErrSchemaTooNew = errors.New("database schema is too new for this version of lily")
 	ErrNameTooLong  = errors.New("name exceeds maximum length for postgres application names")
 )
 


### PR DESCRIPTION
- closes #909