### PR TITLE
Frrist/watcher state cleanup

### DIFF
--- a/chain/watcher.go
+++ b/chain/watcher.go
@@ -56,6 +56,9 @@ func (c *Watcher) Run(ctx context.Context) error {
 		c.pool.Stop()
 		// ensure we clear the fatal error after shut down, this allows the watcher to be restarted without reinitializing its state.
 		c.setFatalError(nil)
+		// ensure we reset the tipset cache to avoid process stale state if watcher is restarted.
+		// TODO: if the watcher is restarted the cache will not be warmed.
+		c.cache.Reset()
 		close(c.done)
 	}()
 	c.pool = workerpool.New(c.poolSize)

--- a/chain/watcher_test.go
+++ b/chain/watcher_test.go
@@ -74,8 +74,8 @@ func TestWatcher(t *testing.T) {
 	im, err := indexer.NewManager(taskAPI, strg, t.Name(), []string{indexer.BlocksTask}, indexer.WithWindow(builtin.EpochDurationSeconds*time.Second))
 	require.NoError(t, err, "NewManager")
 	t.Logf("initializing indexer")
-	idx := NewWatcher(im, NullHeadNotifier{}, NewTipSetCache(0), 1)
-	// the watchers worker pool is initialized in its Run method, since we don't call that here initialize the pool now.
+	idx := NewWatcher(nil, im, 0, 1, 5)
+	// the watchers worker pool and cache are initialized in its Run method, since we don't call that here initialize them now.
 	idx.pool = workerpool.New(1)
 
 	newHeads, err := full.ChainNotify(ctx)

--- a/commands/watch.go
+++ b/commands/watch.go
@@ -23,6 +23,7 @@ type watchOps struct {
 	apiToken   string
 	name       string
 	workers    int
+	bufferSize int
 }
 
 var watchFlags watchOps
@@ -44,6 +45,13 @@ var WatchCmd = &cli.Command{
 			EnvVars:     []string{"LILY_WATCH_WORKERS"},
 			Value:       4,
 			Destination: &watchFlags.workers,
+		},
+		&cli.IntFlag{
+			Name:        "buffer-size",
+			Usage:       "Set the number of tipsets the watcher will buffer while waiting for a worker to accept the work",
+			EnvVars:     []string{"LILY_WATCH_BUFFER"},
+			Value:       5,
+			Destination: &watchFlags.bufferSize,
 		},
 		&cli.StringFlag{
 			Name:        "tasks",
@@ -111,6 +119,7 @@ var WatchCmd = &cli.Command{
 			RestartOnFailure:    true,
 			Storage:             watchFlags.storage,
 			Workers:             watchFlags.workers,
+			BufferSize:          watchFlags.bufferSize,
 		}
 
 		api, closer, err := GetAPI(ctx, watchFlags.apiAddr, watchFlags.apiToken)

--- a/lens/lily/api.go
+++ b/lens/lily/api.go
@@ -84,6 +84,7 @@ type LilyWatchConfig struct {
 	RestartDelay        time.Duration
 	Storage             string // name of storage system to use, may be empty
 	Workers             int    // number of indexing jobs that can run in parallel
+	BufferSize          int    // number of tipsets to buffer from notifier service
 }
 
 type LilyWalkConfig struct {

--- a/lens/lily/impl.go
+++ b/lens/lily/impl.go
@@ -3,6 +3,7 @@ package lily
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync"
 
 	"github.com/filecoin-project/go-state-types/abi"
@@ -134,14 +135,16 @@ func (m *LilyNodeAPI) LilyWatch(_ context.Context, cfg *LilyWatchConfig) (*sched
 		Type: "watch",
 		Params: map[string]string{
 			"window":     cfg.Window.String(),
-			"confidence": fmt.Sprintf("%d", cfg.Confidence),
 			"storage":    cfg.Storage,
+			"confidence": strconv.Itoa(cfg.Confidence),
+			"worker":     strconv.Itoa(cfg.Workers),
+			"buffer":     strconv.Itoa(cfg.BufferSize),
 		},
 		Tasks: cfg.Tasks,
 		Job: chain.NewWatcher(&watcherAPIWrapper{
 			Events:         m.Events,
 			ChainModuleAPI: m.ChainModuleAPI,
-		}, im, cfg.Confidence, cfg.Workers, 5),
+		}, im, cfg.Confidence, cfg.Workers, cfg.BufferSize),
 		RestartOnFailure:    cfg.RestartOnFailure,
 		RestartOnCompletion: cfg.RestartOnCompletion,
 		RestartDelay:        cfg.RestartDelay,

--- a/lens/lily/impl.go
+++ b/lens/lily/impl.go
@@ -526,9 +526,13 @@ func (h *HeadNotifier) Apply(ctx context.Context, from, to *types.TipSet) error 
 	}
 
 	log.Debugw("head notifier apply", "to", to.Key().String(), "from", from.Key().String())
-	ev <- &chain.HeadEvent{
+	select {
+	case ev <- &chain.HeadEvent{
 		Type:   chain.HeadEventApply,
 		TipSet: to,
+	}:
+	default:
+		log.Errorw("head notifier event channel blocked dropping apply event", "to", to.Key().String(), "from", from.Key().String())
 	}
 	return nil
 }
@@ -550,9 +554,13 @@ func (h *HeadNotifier) Revert(ctx context.Context, from, to *types.TipSet) error
 	}
 
 	log.Debugw("head notifier revert", "to", to.Key().String(), "from", from.Key().String())
-	ev <- &chain.HeadEvent{
+	select {
+	case ev <- &chain.HeadEvent{
 		Type:   chain.HeadEventRevert,
 		TipSet: from,
+	}:
+	default:
+		log.Errorw("head notifier event channel blocked dropping revert event", "to", to.Key().String(), "from", from.Key().String())
 	}
 	return nil
 }

--- a/lens/lily/impl.go
+++ b/lens/lily/impl.go
@@ -99,6 +99,11 @@ func (m *LilyNodeAPI) LilyIndex(_ context.Context, cfg *LilyIndexConfig) (interf
 
 }
 
+type watcherAPIWrapper struct {
+	*events.Events
+	full.ChainModuleAPI
+}
+
 func (m *LilyNodeAPI) LilyWatch(_ context.Context, cfg *LilyWatchConfig) (*schedule.JobSubmitResult, error) {
 	// the context's passed to these methods live for the duration of the clients request, so make a new one.
 	ctx := context.Background()
@@ -113,11 +118,6 @@ func (m *LilyNodeAPI) LilyWatch(_ context.Context, cfg *LilyWatchConfig) (*sched
 		return nil, err
 	}
 
-	// HeadNotifier bridges between the event system and the watcher
-	obs := &HeadNotifier{
-		bufferSize: 5,
-	}
-
 	taskAPI, err := datasource.NewDataSource(m)
 	if err != nil {
 		return nil, err
@@ -129,18 +129,6 @@ func (m *LilyNodeAPI) LilyWatch(_ context.Context, cfg *LilyWatchConfig) (*sched
 		return nil, err
 	}
 
-	// Hook up the notifier to the event system
-	head := m.Events.Observe(obs)
-	if err := obs.SetCurrent(ctx, head); err != nil {
-		return nil, err
-	}
-
-	// warm the tipset cache.
-	tsCache := chain.NewTipSetCache(cfg.Confidence)
-	if err := tsCache.Warm(ctx, head, m.ChainModuleAPI.ChainGetTipSet); err != nil {
-		return nil, err
-	}
-
 	res := m.Scheduler.Submit(&schedule.JobConfig{
 		Name: cfg.Name,
 		Type: "watch",
@@ -149,8 +137,11 @@ func (m *LilyNodeAPI) LilyWatch(_ context.Context, cfg *LilyWatchConfig) (*sched
 			"confidence": fmt.Sprintf("%d", cfg.Confidence),
 			"storage":    cfg.Storage,
 		},
-		Tasks:               cfg.Tasks,
-		Job:                 chain.NewWatcher(im, obs, tsCache, cfg.Workers),
+		Tasks: cfg.Tasks,
+		Job: chain.NewWatcher(&watcherAPIWrapper{
+			Events:         m.Events,
+			ChainModuleAPI: m.ChainModuleAPI,
+		}, im, cfg.Confidence, cfg.Workers, 5),
 		RestartOnFailure:    cfg.RestartOnFailure,
 		RestartOnCompletion: cfg.RestartOnCompletion,
 		RestartDelay:        cfg.RestartDelay,
@@ -435,134 +426,6 @@ func (m *LilyNodeAPI) LilySurvey(_ context.Context, cfg *LilySurveyConfig) (*sch
 	})
 
 	return res, nil
-}
-
-var _ events.TipSetObserver = (*HeadNotifier)(nil)
-
-type HeadNotifier struct {
-	mu     sync.Mutex            // protects following fields
-	events chan *chain.HeadEvent // created lazily, closed by first cancel call
-	err    error                 // set to non-nil by the first cancel call
-
-	// size of the buffer to maintain for events. Using a buffer reduces chance
-	// that the emitter of events will block when sending to this notifier.
-	bufferSize int
-}
-
-func (h *HeadNotifier) eventsCh() chan *chain.HeadEvent {
-	// caller must hold mu
-	if h.events == nil {
-		h.events = make(chan *chain.HeadEvent, h.bufferSize)
-	}
-	return h.events
-}
-
-func (h *HeadNotifier) HeadEvents() <-chan *chain.HeadEvent {
-	h.mu.Lock()
-	ev := h.eventsCh()
-	h.mu.Unlock()
-	return ev
-}
-
-func (h *HeadNotifier) Err() error {
-	h.mu.Lock()
-	err := h.err
-	h.mu.Unlock()
-	return err
-}
-
-func (h *HeadNotifier) Cancel(err error) {
-	h.mu.Lock()
-	if h.err != nil {
-		h.mu.Unlock()
-		return
-	}
-	h.err = err
-	if h.events == nil {
-		h.events = make(chan *chain.HeadEvent, h.bufferSize)
-	}
-	close(h.events)
-	h.mu.Unlock()
-}
-
-func (h *HeadNotifier) SetCurrent(ctx context.Context, ts *types.TipSet) error {
-	h.mu.Lock()
-	if h.err != nil {
-		err := h.err
-		h.mu.Unlock()
-		return err
-	}
-	ev := h.eventsCh()
-	h.mu.Unlock()
-
-	// This is imprecise since it's inherently racy but good enough to emit
-	// a warning that the event may block the sender
-	if len(ev) == cap(ev) {
-		log.Warnw("head notifier buffer at capacity", "queued", len(ev))
-	}
-
-	log.Debugw("head notifier setting head", "tipset", ts.Key().String())
-	ev <- &chain.HeadEvent{
-		Type:   chain.HeadEventCurrent,
-		TipSet: ts,
-	}
-	return nil
-}
-
-func (h *HeadNotifier) Apply(ctx context.Context, from, to *types.TipSet) error {
-	h.mu.Lock()
-	if h.err != nil {
-		err := h.err
-		h.mu.Unlock()
-		return err
-	}
-	ev := h.eventsCh()
-	h.mu.Unlock()
-
-	// This is imprecise since it's inherently racy but good enough to emit
-	// a warning that the event may block the sender
-	if len(ev) == cap(ev) {
-		log.Warnw("head notifier buffer at capacity", "queued", len(ev))
-	}
-
-	log.Debugw("head notifier apply", "to", to.Key().String(), "from", from.Key().String())
-	select {
-	case ev <- &chain.HeadEvent{
-		Type:   chain.HeadEventApply,
-		TipSet: to,
-	}:
-	default:
-		log.Errorw("head notifier event channel blocked dropping apply event", "to", to.Key().String(), "from", from.Key().String())
-	}
-	return nil
-}
-
-func (h *HeadNotifier) Revert(ctx context.Context, from, to *types.TipSet) error {
-	h.mu.Lock()
-	if h.err != nil {
-		err := h.err
-		h.mu.Unlock()
-		return err
-	}
-	ev := h.eventsCh()
-	h.mu.Unlock()
-
-	// This is imprecise since it's inherently racy but good enough to emit
-	// a warning that the event may block the sender
-	if len(ev) == cap(ev) {
-		log.Warnw("head notifier buffer at capacity", "queued", len(ev))
-	}
-
-	log.Debugw("head notifier revert", "to", to.Key().String(), "from", from.Key().String())
-	select {
-	case ev <- &chain.HeadEvent{
-		Type:   chain.HeadEventRevert,
-		TipSet: from,
-	}:
-	default:
-		log.Errorw("head notifier event channel blocked dropping revert event", "to", to.Key().String(), "from", from.Key().String())
-	}
-	return nil
 }
 
 // used for debugging querries, call ORM.AddHook and this will print all queries.


### PR DESCRIPTION
This change allows the watcher to be stopped and started without keeping stale state around: state includes workerpool, tipset cache, and notifier. This change will have a follow on once https://github.com/filecoin-project/lotus/pull/8441 lands in a release.