### PR TITLE
chore: reject invalid tasks on client

### DIFF
--- a/commands/job/fill.go
+++ b/commands/job/fill.go
@@ -1,11 +1,13 @@
 package job
 
 import (
+	"fmt"
 	"os"
 
 	lotuscli "github.com/filecoin-project/lotus/cli"
 	"github.com/urfave/cli/v2"
 
+	"github.com/filecoin-project/lily/chain/indexer/tasktype"
 	"github.com/filecoin-project/lily/commands"
 	"github.com/filecoin-project/lily/lens/lily"
 )
@@ -35,6 +37,14 @@ Constraints:
 		GapFillNotifyCmd,
 	},
 	Before: func(cctx *cli.Context) error {
+		tasks := RunFlags.Tasks.Value()
+		for _, taskName := range tasks {
+			if _, found := tasktype.TaskLookup[taskName]; found {
+			} else if _, found := tasktype.TableLookup[taskName]; found {
+			} else {
+				return fmt.Errorf("unknown task: %s", taskName)
+			}
+		}
 		return rangeFlags.validate()
 	},
 	Action: func(cctx *cli.Context) error {

--- a/commands/job/find.go
+++ b/commands/job/find.go
@@ -1,11 +1,13 @@
 package job
 
 import (
+	"fmt"
 	"os"
 
 	lotuscli "github.com/filecoin-project/lotus/cli"
 	"github.com/urfave/cli/v2"
 
+	"github.com/filecoin-project/lily/chain/indexer/tasktype"
 	"github.com/filecoin-project/lily/commands"
 	"github.com/filecoin-project/lily/lens/lily"
 )
@@ -35,6 +37,14 @@ since visor_processing_report entries will not be present for imported data (mea
 		RangeToFlag,
 	},
 	Before: func(cctx *cli.Context) error {
+		tasks := RunFlags.Tasks.Value()
+		for _, taskName := range tasks {
+			if _, found := tasktype.TaskLookup[taskName]; found {
+			} else if _, found := tasktype.TableLookup[taskName]; found {
+			} else {
+				return fmt.Errorf("unknown task: %s", taskName)
+			}
+		}
 		return rangeFlags.validate()
 	},
 	Action: func(cctx *cli.Context) error {

--- a/commands/job/index.go
+++ b/commands/job/index.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/urfave/cli/v2"
 
+	"github.com/filecoin-project/lily/chain/indexer/tasktype"
 	"github.com/filecoin-project/lily/commands"
 	"github.com/filecoin-project/lily/lens/lily"
 )
@@ -32,6 +33,17 @@ The index command may be used to index a single tipset from the filecoin blockch
 	Subcommands: []*cli.Command{
 		IndexTipSetCmd,
 		IndexHeightCmd,
+	},
+	Before: func(cctx *cli.Context) error {
+		tasks := RunFlags.Tasks.Value()
+		for _, taskName := range tasks {
+			if _, found := tasktype.TaskLookup[taskName]; found {
+			} else if _, found := tasktype.TableLookup[taskName]; found {
+			} else {
+				return fmt.Errorf("unknown task: %s", taskName)
+			}
+		}
+		return nil
 	},
 }
 

--- a/commands/job/survey.go
+++ b/commands/job/survey.go
@@ -1,6 +1,7 @@
 package job
 
 import (
+	"fmt"
 	"os"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 
 	"github.com/filecoin-project/lily/commands"
 	"github.com/filecoin-project/lily/lens/lily"
+	"github.com/filecoin-project/lily/network"
 )
 
 var surveyFlags struct {
@@ -28,6 +30,16 @@ var SurveyCmd = &cli.Command{
 			Value:       10 * time.Minute,
 			Destination: &surveyFlags.interval,
 		},
+	},
+	Before: func(cctx *cli.Context) error {
+		tasks := RunFlags.Tasks.Value()
+		if len(tasks) != 1 {
+			return fmt.Errorf("survey accepts single task type: '%s'", network.PeerAgentsTask)
+		}
+		if tasks[0] != network.PeerAgentsTask {
+			return fmt.Errorf("unknown task: %s", tasks[0])
+		}
+		return nil
 	},
 	Action: func(cctx *cli.Context) error {
 		ctx := lotuscli.ReqContext(cctx)

--- a/commands/job/walk.go
+++ b/commands/job/walk.go
@@ -1,11 +1,13 @@
 package job
 
 import (
+	"fmt"
 	"os"
 
 	lotuscli "github.com/filecoin-project/lotus/cli"
 	"github.com/urfave/cli/v2"
 
+	"github.com/filecoin-project/lily/chain/indexer/tasktype"
 	"github.com/filecoin-project/lily/commands"
 	"github.com/filecoin-project/lily/lens/lily"
 )
@@ -30,6 +32,14 @@ The status of each epoch and its set of tasks can be observed in the visor_proce
 		WalkNotifyCmd,
 	},
 	Before: func(cctx *cli.Context) error {
+		tasks := RunFlags.Tasks.Value()
+		for _, taskName := range tasks {
+			if _, found := tasktype.TaskLookup[taskName]; found {
+			} else if _, found := tasktype.TableLookup[taskName]; found {
+			} else {
+				return fmt.Errorf("unknown task: %s", taskName)
+			}
+		}
 		return rangeFlags.validate()
 	},
 	Action: func(cctx *cli.Context) error {

--- a/commands/job/watch.go
+++ b/commands/job/watch.go
@@ -1,11 +1,13 @@
 package job
 
 import (
+	"fmt"
 	"os"
 
 	lotuscli "github.com/filecoin-project/lotus/cli"
 	"github.com/urfave/cli/v2"
 
+	"github.com/filecoin-project/lily/chain/indexer/tasktype"
 	"github.com/filecoin-project/lily/commands"
 	"github.com/filecoin-project/lily/lens/lily"
 	"github.com/filecoin-project/lily/schedule"
@@ -85,6 +87,17 @@ watches the chain head and only indexes a tipset after observing 10 subsequent t
 		WatchConfidenceFlag,
 		WatchWorkersFlag,
 		WatchBufferSizeFlag,
+	},
+	Before: func(cctx *cli.Context) error {
+		tasks := RunFlags.Tasks.Value()
+		for _, taskName := range tasks {
+			if _, found := tasktype.TaskLookup[taskName]; found {
+			} else if _, found := tasktype.TableLookup[taskName]; found {
+			} else {
+				return fmt.Errorf("unknown task: %s", taskName)
+			}
+		}
+		return nil
 	},
 	Subcommands: []*cli.Command{
 		WatchNotifyCmd,


### PR DESCRIPTION
closes #969

Ideally, this check would be performed once in a `job run` `Before` [option](https://github.com/filecoin-project/lily/blob/master/commands/job/job.go#L27), but that would break the `survey` command since it uses different task names. This is making me rethink if the `survey` job should go somewhere else. Thoughts?