### PR TITLE
chore: improve distributed indexing metrics and logging

### DIFF
--- a/chain/indexer/distributed/queue/tasks/gapfill.go
+++ b/chain/indexer/distributed/queue/tasks/gapfill.go
@@ -9,7 +9,10 @@ import (
 	"github.com/filecoin-project/lotus/blockstore"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/hibiken/asynq"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/filecoin-project/lily/chain/indexer"
 	"github.com/filecoin-project/lily/chain/indexer/distributed/queue/tracing"
@@ -21,14 +24,32 @@ const (
 )
 
 type GapFillTipSetPayload struct {
-	TipSet *types.TipSet
-	// TODO include the height of the tipset here to correctly mark the epoch as gap filled cuz Null rounds
+	TipSet       *types.TipSet
 	Tasks        []string
 	TraceCarrier *tracing.TraceCarrier `json:",omitempty"`
 }
 
+// Attributes returns a slice of attributes for populating tracing span attributes.
+func (g GapFillTipSetPayload) Attributes() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.Int64("height", int64(g.TipSet.Height())),
+		attribute.String("tipset", g.TipSet.Key().String()),
+		attribute.StringSlice("tasks", g.Tasks),
+	}
+}
+
+// MarshalLogObject implement ObjectMarshaler and allows user-defined types to efficiently add themselves to the
+// logging context, and to selectively omit information which shouldn't be
+// included in logs (e.g., passwords).
+func (g GapFillTipSetPayload) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("tipset", g.TipSet.Key().String())
+	enc.AddInt64("height", int64(g.TipSet.Height()))
+	enc.AddString("tasks", fmt.Sprint(g.Tasks))
+	return nil
+}
+
 // HasTraceCarrier returns true iff payload contains a trace.
-func (g *GapFillTipSetPayload) HasTraceCarrier() bool {
+func (g GapFillTipSetPayload) HasTraceCarrier() bool {
 	return !(g.TraceCarrier == nil)
 }
 
@@ -54,32 +75,40 @@ func (gh *AsynqGapFillTipSetTaskHandler) HandleGapFillTipSetTask(ctx context.Con
 	if err := json.Unmarshal(t.Payload(), &p); err != nil {
 		return err
 	}
-	log.Infow("gap fill tipset", "tipset", p.TipSet.String(), "height", p.TipSet.Height(), "tasks", p.Tasks)
+
+	taskID := t.ResultWriter().TaskID()
+	log.Infow("gap fill tipset", "taskID", taskID, zap.Inline(p))
 
 	if p.HasTraceCarrier() {
 		if sc := p.TraceCarrier.AsSpanContext(); sc.IsValid() {
 			ctx = trace.ContextWithRemoteSpanContext(ctx, sc)
+		}
+		span := trace.SpanFromContext(ctx)
+		if span.IsRecording() {
+			span.SetAttributes(attribute.String("taskID", t.ResultWriter().TaskID()))
+			span.SetAttributes(p.Attributes()...)
 		}
 	}
 
 	success, err := gh.indexer.TipSet(ctx, p.TipSet, indexer.WithTasks(p.Tasks))
 	if err != nil {
 		if strings.Contains(err.Error(), blockstore.ErrNotFound.Error()) {
+			log.Errorw("failed to index tipset for gap fill", zap.Inline(p), "error", err)
 			// return SkipRetry to prevent the task from being retried since nodes do not contain the block
-			// TODO: later, reschedule task in "backfill" queue with lily nodes capable of syncing the required data.
-			return fmt.Errorf("indexing tipset for gap fill tipset.(height) %s.(%d): Error %s : %w", p.TipSet.Key().String(), p.TipSet.Height(), err, asynq.SkipRetry)
+			return fmt.Errorf("indexing tipset for gap fill %s.(%d) taskID %s: Error %s : %w", p.TipSet.Key().String(), p.TipSet.Height(), taskID, err, asynq.SkipRetry)
 		} else {
 			return err
 		}
 	}
 	if !success {
-		log.Errorw("failed to gap fill task successfully", "height", p.TipSet.Height(), "tipset", p.TipSet.Key().String())
-		return fmt.Errorf("gap filling tipset.(height) %s.(%d)", p.TipSet.Key(), p.TipSet.Height())
+		log.Errorw("failed to gap fill task successfully", "taskID", taskID, zap.Inline(p))
+		return fmt.Errorf("gap filling tipset.(height) %s.(%d) taskID: %s", p.TipSet.Key(), p.TipSet.Height(), taskID)
 	} else {
 		if err := gh.db.SetGapsFilled(ctx, int64(p.TipSet.Height()), p.Tasks...); err != nil {
-			log.Errorw("failed to mark gap as filled", "error", err)
+			log.Errorw("failed to mark gap as filled", "taskID", taskID, zap.Inline(p), "error", err)
 			return err
 		}
 	}
+	log.Infow("gap fill tipset success", "taskID", taskID, zap.Inline(p))
 	return nil
 }

--- a/commands/daemon.go
+++ b/commands/daemon.go
@@ -20,6 +20,8 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/urfave/cli/v2"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 
 	"github.com/filecoin-project/lily/chain/indexer/distributed"
 	"github.com/filecoin-project/lily/commands/util"
@@ -27,8 +29,10 @@ import (
 	"github.com/filecoin-project/lily/lens/lily"
 	"github.com/filecoin-project/lily/lens/lily/modules"
 	lutil "github.com/filecoin-project/lily/lens/util"
+	"github.com/filecoin-project/lily/metrics"
 	"github.com/filecoin-project/lily/schedule"
 	"github.com/filecoin-project/lily/storage"
+	"github.com/filecoin-project/lily/version"
 )
 
 var ClientAPIFlags struct {
@@ -204,6 +208,11 @@ Note that jobs are not persisted between restarts of the daemon. See
 				log.Infof("lily config: %s", daemonFlags.config)
 			}
 		}
+
+		ctx, _ = tag.New(ctx,
+			tag.Insert(metrics.Version, version.String()),
+		)
+		stats.Record(ctx, metrics.LilyInfo.M(1))
 
 		if err := config.EnsureExists(daemonFlags.config); err != nil {
 			return fmt.Errorf("ensuring config is present at %q: %w", daemonFlags.config, err)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -12,29 +12,39 @@ import (
 var defaultMillisecondsDistribution = view.Distribution(0.01, 0.05, 0.1, 0.3, 0.6, 0.8, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 30000, 50000, 100000, 200000, 500000, 1000000, 2000000, 5000000, 10000000, 10000000)
 
 var (
-	TaskType, _  = tag.NewKey("task")  // name of task processor
-	Job, _       = tag.NewKey("job")   // name of job
-	Name, _      = tag.NewKey("name")  // name of running instance of visor
-	Table, _     = tag.NewKey("table") // name of table data is persisted for
+	Version, _   = tag.NewKey("version")
+	TaskType, _  = tag.NewKey("task")     // name of task processor
+	Job, _       = tag.NewKey("job")      // name of job
+	JobType, _   = tag.NewKey("job_type") // type of job (walk, watch, fill, find, watch-notify, walk-notify, etc.)
+	Name, _      = tag.NewKey("name")     // name of running instance of visor
+	Table, _     = tag.NewKey("table")    // name of table data is persisted for
 	ConnState, _ = tag.NewKey("conn_state")
 	API, _       = tag.NewKey("api")        // name of method on lotus api
 	ActorCode, _ = tag.NewKey("actor_code") // human readable code of actor being processed
 
+	// distributed tipset worker
+	QueueName = tag.MustNewKey("queue")
 )
 
 var (
+	// Common State
+
+	LilyInfo = stats.Int64("lily_info", "Arbitrary counter to tag lily info to", stats.UnitDimensionless)
+
+	// Indexer State
+
 	ProcessingDuration      = stats.Float64("processing_duration_ms", "Time taken to process a task", stats.UnitMilliseconds)
 	StateExtractionDuration = stats.Float64("state_extraction_duration_ms", "Time taken to extract an actor state", stats.UnitMilliseconds)
 	PersistDuration         = stats.Float64("persist_duration_ms", "Duration of a models persist operation", stats.UnitMilliseconds)
 	PersistModel            = stats.Int64("persist_model", "Number of models persisted", stats.UnitDimensionless)
 	DBConns                 = stats.Int64("db_conns", "Database connections held", stats.UnitDimensionless)
-	LensRequestDuration     = stats.Float64("lens_request_duration_ms", "Duration of lotus api requets", stats.UnitMilliseconds)
 	TipsetHeight            = stats.Int64("tipset_height", "The height of the tipset being processed by a task", stats.UnitDimensionless)
 	ProcessingFailure       = stats.Int64("processing_failure", "Number of processing failures", stats.UnitDimensionless)
 	PersistFailure          = stats.Int64("persist_failure", "Number of persistence failures", stats.UnitDimensionless)
 	WatchHeight             = stats.Int64("watch_height", "The height of the tipset last seen by the watch command", stats.UnitDimensionless)
 	TipSetSkip              = stats.Int64("tipset_skip", "Number of tipsets that were not processed. This is is an indication that lily cannot keep up with chain.", stats.UnitDimensionless)
 	JobStart                = stats.Int64("job_start", "Number of jobs started", stats.UnitDimensionless)
+	JobRunning              = stats.Int64("job_running", "Numer of jobs currently running", stats.UnitDimensionless)
 	JobComplete             = stats.Int64("job_complete", "Number of jobs completed without error", stats.UnitDimensionless)
 	JobError                = stats.Int64("job_error", "Number of jobs stopped due to a fatal error", stats.UnitDimensionless)
 	JobTimeout              = stats.Int64("job_timeout", "Number of jobs stopped due to taking longer than expected", stats.UnitDimensionless)
@@ -43,6 +53,8 @@ var (
 	TipSetCacheEmptyRevert  = stats.Int64("tipset_cache_empty_revert", "Number of revert operations performed on an empty tipset cache. This is an indication that a chain reorg is underway that is deeper than the cache size and includes tipsets that have already been read from the cache.", stats.UnitDimensionless)
 	WatcherActiveWorkers    = stats.Int64("watcher_active_workers", "Current number of tipset indexers executing", stats.UnitDimensionless)
 	WatcherWaitingWorkers   = stats.Int64("watcher_waiting_workers", "Current number of tipset indexers waiting to execute", stats.UnitDimensionless)
+
+	// DataSource API
 
 	DataSourceSectorDiffCacheHit               = stats.Int64("data_source_sector_diff_cache_hit", "Number of cache hits for sector diff", stats.UnitDimensionless)
 	DataSourceSectorDiffRead                   = stats.Int64("data_source_sector_diff_read", "Number of reads for sector diff", stats.UnitDimensionless)
@@ -54,9 +66,29 @@ var (
 	DataSourceExecutedAndBlockMessagesCacheHit = stats.Int64("data_source_executed_block_messages_cache_hig", "Number of cache hits for executed block messages", stats.UnitDimensionless)
 	DataSourceActorStateChangesFastDiff        = stats.Int64("data_source_actor_state_changes_fast_diff", "Number of fast diff operations performed for actor state changes", stats.UnitDimensionless)
 	DataSourceActorStateChangesSlowDiff        = stats.Int64("data_source_actor_state_changes_slow_diff", "Number of slow diff operations performed for actor state changes", stats.UnitDimensionless)
+
+	// Distributed Indexer
+
+	TipSetWorkerConcurrency   = stats.Int64("tipset_worker_concurrency", "Concurrency of tipset worker", stats.UnitDimensionless)
+	TipSetWorkerQueuePriority = stats.Int64("tipset_worker_queue_priority", "Priority of tipset worker queue", stats.UnitDimensionless)
 )
 
 var DefaultViews = []*view.View{
+	{
+		Measure:     LilyInfo,
+		Aggregation: view.LastValue(),
+		TagKeys:     []tag.Key{Version},
+	},
+	{
+		Measure:     TipSetWorkerConcurrency,
+		Aggregation: view.LastValue(),
+		TagKeys:     []tag.Key{},
+	},
+	{
+		Measure:     TipSetWorkerQueuePriority,
+		Aggregation: view.LastValue(),
+		TagKeys:     []tag.Key{QueueName},
+	},
 	{
 		Measure:     DataSourceActorStateChangesFastDiff,
 		Aggregation: view.Count(),
@@ -128,17 +160,6 @@ var DefaultViews = []*view.View{
 		TagKeys:     []tag.Key{ConnState},
 	},
 	{
-		Measure:     LensRequestDuration,
-		Aggregation: defaultMillisecondsDistribution,
-		TagKeys:     []tag.Key{TaskType, API, ActorCode},
-	},
-	{
-		Name:        "lens_request_total",
-		Measure:     LensRequestDuration,
-		Aggregation: view.Count(),
-		TagKeys:     []tag.Key{TaskType, API, ActorCode},
-	},
-	{
 		Measure:     TipsetHeight,
 		Aggregation: view.LastValue(),
 		TagKeys:     []tag.Key{TaskType, Job},
@@ -166,30 +187,34 @@ var DefaultViews = []*view.View{
 		Aggregation: view.Sum(),
 		TagKeys:     []tag.Key{Job},
 	},
-
+	{
+		Measure:     JobRunning,
+		Aggregation: view.Sum(),
+		TagKeys:     []tag.Key{Job, JobType},
+	},
 	{
 		Name:        JobStart.Name() + "_total",
 		Measure:     JobStart,
 		Aggregation: view.Count(),
-		TagKeys:     []tag.Key{Job},
+		TagKeys:     []tag.Key{Job, JobType},
 	},
 	{
 		Name:        JobComplete.Name() + "_total",
 		Measure:     JobComplete,
 		Aggregation: view.Count(),
-		TagKeys:     []tag.Key{Job},
+		TagKeys:     []tag.Key{Job, JobType},
 	},
 	{
 		Name:        JobError.Name() + "_total",
 		Measure:     JobError,
 		Aggregation: view.Count(),
-		TagKeys:     []tag.Key{Job},
+		TagKeys:     []tag.Key{Job, JobType},
 	},
 	{
 		Name:        JobTimeout.Name() + "_total",
 		Measure:     JobTimeout,
 		Aggregation: view.Count(),
-		TagKeys:     []tag.Key{Job},
+		TagKeys:     []tag.Key{Job, JobType},
 	},
 
 	{


### PR DESCRIPTION
### What
- Improves logging and tracing around distributed indexing - include taskIDs in log messages and traces
- Add `lily_info` metric that contains a label with the lily version
- Add `job_running` metric indicating which jobs are running and their type (alk, watch, fill, find, watch-notify, walk-notify, etc.)
- Add `tipset_worker_concurrency` indicating concurrency configuration of tipset workers
- Add `tipset_worker_queue_priority` indicating tipset worker queue priorities configuration.

