### PR TITLE
chore: walk test uses in memory storage

### DIFF
--- a/testutil/filtypes.go
+++ b/testutil/filtypes.go
@@ -45,6 +45,15 @@ func (b BlockHeaderList) Cids() []string {
 	return cids
 }
 
+func (b BlockHeaderList) Heights() []int64 {
+	var heights []int64
+	for _, bh := range b {
+		heights = append(heights, int64(bh.Height))
+	}
+	return heights
+
+}
+
 func (b BlockHeaderList) Rounds() []uint64 {
 	var rounds []uint64
 	for _, bh := range b {


### PR DESCRIPTION
- reduce the requirements for running test

I have noticed this test [flakes sometimes](https://app.circleci.com/pipelines/github/filecoin-project/lily/3536/workflows/6ef9122e-0372-4bd6-8041-0c6505b958d3/jobs/15593). On the off chance this is a race condition within Postgres I have removed it as a dependency of the test opting to use an in-memory storage type instead.