### PR TITLE
Fix a typo or a bug for command help text: job run find

### DIFF
--- a/commands/job/find.go
+++ b/commands/job/find.go
@@ -24,7 +24,7 @@ An epoch is considered to have gaps iff:
 The results of the find job are written to the visor_gap_reports table with status 'GAP'.
 
 As an example, the below command:
- $ lily job run --tasks=block_headers,messages find --from=10 --to=20
+ $ lily job run --tasks=block_header,messages find --from=10 --to=20
 searches for gaps in block_headers and messages tasks from epoch 10 to 20 (inclusive). 
 
 Constraints:


### PR DESCRIPTION
the help text's example is wrong, the task name: block_headers will not match the` tasktype.TableLookup.`