### PR TITLE
feat: add index on events covering height and miner_id

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,6 +193,7 @@ jobs:
       - image: timescale/timescaledb:2.5.0-pg13
         environment:
           POSTGRES_PASSWORD: password
+          TS_TUNE_NUM_CPUS: 0
     steps:
       - checkout
       - prepare
@@ -228,6 +229,7 @@ jobs:
       - image: timescale/timescaledb:2.5.0-pg13
         environment:
           POSTGRES_PASSWORD: password
+          TS_TUNE_NUM_CPUS: 0
     steps:
       - checkout
       - prepare

--- a/schemas/v1/8_miner_sector_events_idx.go
+++ b/schemas/v1/8_miner_sector_events_idx.go
@@ -8,7 +8,7 @@ func init() {
 -- Name: miner_sector_events_event_idx
 -- Model: miner.MinerSectorEvent
 -- ----------------------------------------------------------------
-CREATE INDEX miner_sector_events_event_idx ON {{ .SchemaName | default "public"}}.miner_sector_events USING btree(event) INCLUDE(height, miner_id);
+CREATE INDEX CONCURRENTLY miner_sector_events_event_idx ON {{ .SchemaName | default "public"}}.miner_sector_events USING btree(event) INCLUDE(height, miner_id);
 `,
 	)
 }

--- a/schemas/v1/8_miner_sector_events_idx.go
+++ b/schemas/v1/8_miner_sector_events_idx.go
@@ -8,7 +8,7 @@ func init() {
 -- Name: miner_sector_events_event_idx
 -- Model: miner.MinerSectorEvent
 -- ----------------------------------------------------------------
-CREATE INDEX CONCURRENTLY miner_sector_events_event_idx ON {{ .SchemaName | default "public"}}.miner_sector_events
+CREATE INDEX miner_sector_events_event_idx ON {{ .SchemaName | default "public"}}.miner_sector_events
 	USING btree(event) INCLUDE(height, miner_id) WITH(timescaledb.transaction_per_chunk);
 `,
 	)

--- a/schemas/v1/8_miner_sector_events_idx.go
+++ b/schemas/v1/8_miner_sector_events_idx.go
@@ -8,7 +8,8 @@ func init() {
 -- Name: miner_sector_events_event_idx
 -- Model: miner.MinerSectorEvent
 -- ----------------------------------------------------------------
-CREATE INDEX CONCURRENTLY miner_sector_events_event_idx ON {{ .SchemaName | default "public"}}.miner_sector_events USING btree(event) INCLUDE(height, miner_id);
+CREATE INDEX CONCURRENTLY miner_sector_events_event_idx ON {{ .SchemaName | default "public"}}.miner_sector_events
+	USING btree(event) INCLUDE(height, miner_id) WITH(timescaledb.transaction_per_chunk);
 `,
 	)
 }

--- a/schemas/v1/8_miner_sector_events_idx.go
+++ b/schemas/v1/8_miner_sector_events_idx.go
@@ -1,0 +1,14 @@
+package v1
+
+func init() {
+	patches.Register(
+		8,
+		`
+------------------------------------------------------------------
+-- Name: miner_sector_events_event_idx
+-- Model: miner.MinerSectorEvent
+-- ----------------------------------------------------------------
+CREATE INDEX miner_sector_events_event_idx ON {{ .SchemaName | default "public"}}.miner_sector_events USING btree(event) INCLUDE(height, miner_id);
+`,
+	)
+}


### PR DESCRIPTION
## Background

`miner_sector_events` is a table where we need to do aggregations by some miner and height given an event. Such queries are slow (check [plan here](https://explain.dalibo.com/plan/XTz)). The plan shows that Postgres uses a lot of sequential scans since we scan at least >5% of the table.

## Considerations

Sequential scans are often faster than index scans because it doesn't have to do a visit to the heap once the index has been looked up (ie, several ops per row). Instead it just takes a subset of the table and performs single executions on each row there. My thought process is that with a covered index, we can solve the visit problem by including columns in the index it can get values of height and miner_id without visiting the heap.

More info about covering index [here](https://www.postgresql.org/docs/current/indexes-index-only-scans.html):

> To make effective use of the index-only scan feature, you might choose to create a covering index, which is an index specifically designed to include the columns needed by a particular type of query that you run frequently. Since queries typically need to retrieve more columns than just the ones they search on, PostgreSQL allows you to create an index in which some columns are just “payload” and are not part of the search key. This is done by adding an INCLUDE clause listing the extra columns. For example, if you commonly run queries like

## Local Testing

Using this stripped down query:

```sql
explain analyze
select distinct on (miner_id) miner_id, height, event
from miner_sector_events
where event='SECTOR_ADDED' and height between 1975680 and 1982049;
```

.. we have the following query plan without the proposed index in this PR:

```
                                                                      QUERY PLAN                                                             
-------------------------------------------------------------------------------------------------------------------------------------------------------
 Unique  (cost=272314.99..276081.77 rows=200 width=21) (actual time=1460.412..1472.733 rows=108 loops=1)
   ->  Gather Merge  (cost=272314.99..276004.73 rows=30816 width=21) (actual time=1460.411..1471.232 rows=34588 loops=1)
         Workers Planned: 4
         Workers Launched: 4
         ->  Sort  (cost=271314.93..271334.19 rows=7704 width=21) (actual time=1439.851..1440.160 rows=6918 loops=5)
               Sort Key: _hyper_16_80_chunk.miner_id
               Sort Method: quicksort  Memory: 730kB
               Worker 0:  Sort Method: quicksort  Memory: 767kB
               Worker 1:  Sort Method: quicksort  Memory: 713kB
               Worker 2:  Sort Method: quicksort  Memory: 700kB
               Worker 3:  Sort Method: quicksort  Memory: 754kB
               ->  Parallel Seq Scan on _hyper_16_80_chunk  (cost=0.00..270817.59 rows=7704 width=21) (actual time=10.578..1435.770 rows=6918 loops=5)
                     Filter: ((height >= 1975680) AND (height <= 1982049) AND (event = 'SECTOR_ADDED'::miner_sector_event_type))
                     Rows Removed by Filter: 2619446
 Planning Time: 2.073 ms
 JIT:
   Functions: 21
   Options: Inlining false, Optimization false, Expressions true, Deforming true
   Timing: Generation 1.565 ms, Inlining 0.000 ms, Optimization 3.097 ms, Emission 33.256 ms, Total 37.919 ms
 Execution Time: 1550.585 ms
(20 rows)
```

... with the proposed index in this PR:

```
                                                                                            QUERY PLAN                                       
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Unique  (cost=3982.73..4172.26 rows=852 width=21) (actual time=21.303..25.248 rows=108 loops=1)
   ->  Sort  (cost=3982.73..4077.50 rows=37907 width=21) (actual time=21.301..23.657 rows=34588 loops=1)
         Sort Key: _hyper_16_80_chunk.miner_id
         Sort Method: external merge  Disk: 1272kB
         ->  Index Only Scan using _hyper_16_80_chunk_miner_sector_events_event_idx on _hyper_16_80_chunk  (cost=0.56..1099.87 rows=37907 width=21) (actual time=0.016..4.721 rows=34588 loops=1)
               Index Cond: (event = 'SECTOR_ADDED'::miner_sector_event_type)
               Filter: ((height >= 1975680) AND (height <= 1982049))
               Heap Fetches: 0
 Planning Time: 3.130 ms
 Execution Time: 25.805 ms
(10 rows)
```

## Real Data Testing

[Jump to this comment](https://github.com/filecoin-project/lily/pull/1023#issuecomment-1198371934).


## Vacuuming

I'm not too familiar with how our vacuuming policy currently works and this index might introduce index bloat.