### PR TITLE
feat: add method for finding oldest state and computing state

### DIFF
--- a/commands/chain.go
+++ b/commands/chain.go
@@ -156,10 +156,6 @@ var ChainStateInspect = &cli.Command{
 			Aliases: []string{"v"},
 			Usage:   "Include detailed information about the completeness of state for all traversed height(s) starting from most recent",
 		},
-		&cli.BoolFlag{
-			Name:  "compact",
-			Usage: "Print JSON without whitespace",
-		},
 	},
 	Action: func(cctx *cli.Context) error {
 		ctx := lotuscli.ReqContext(cctx)
@@ -247,7 +243,6 @@ var ChainStateCompute = &cli.Command{
 		bar := pb.StartNew(int(cctx.Uint64("to") - cctx.Uint64("from")))
 		bar.ShowTimeLeft = true
 		bar.ShowPercent = true
-		bar.ShowSpeed = true
 		bar.Units = pb.U_NO
 		for i := cctx.Int64("from"); i <= cctx.Int64("to"); i++ {
 			ts, err := lapi.ChainGetTipSetByHeight(ctx, abi.ChainEpoch(i), head.Key())

--- a/commands/chain.go
+++ b/commands/chain.go
@@ -43,8 +43,7 @@ var ChainCmd = &cli.Command{
 		ChainListCmd,
 		ChainSetHeadCmd,
 		ChainActorCodesCmd,
-		ChainFindOldestState,
-		ChainListStates,
+		ChainStateInspect,
 		ChainStateCompute,
 		ChainStateComputeRange,
 	},
@@ -79,23 +78,87 @@ var ChainActorCodesCmd = &cli.Command{
 	},
 }
 
-func printReport(r []*lily.StateReport) {
-	t := table.NewWriter()
-	t.AppendHeader(table.Row{"Height", "StateTree", "Messages"})
-	for _, v := range r {
-		t.AppendRow(table.Row{v.Height, v.HasState, v.HasMessages})
-		t.AppendSeparator()
+func marshalReport(reports []*lily.StateReport, verbose bool) ([]byte, error) {
+	type stateHeights struct {
+		Newest int64 `json:"newest"`
+		Oldest int64 `json:"oldest"`
 	}
-	fmt.Println(t.Render())
+	type summarizedHeights struct {
+		Messages   stateHeights `json:"messages"`
+		StateRoots stateHeights `json:"stateroots"`
+	}
+	type hasState struct {
+		Messages  bool `json:"messages"`
+		Receipts  bool `json:"receipts"`
+		StateRoot bool `json:"stateroot"`
+	}
+	type stateReport struct {
+		Summary summarizedHeights  `json:"summary"`
+		Detail  map[int64]hasState `json:"details,omitempty"`
+	}
+
+	var (
+		details         = make(map[int64]hasState)
+		headSet         bool
+		head            = reports[0]
+		oldestMessage   = &lily.StateReport{}
+		oldestStateRoot = &lily.StateReport{}
+	)
+
+	for _, r := range reports {
+		if verbose {
+			details[r.Height] = hasState{
+				Messages:  r.HasMessages,
+				Receipts:  r.HasReceipts,
+				StateRoot: r.HasState,
+			}
+		}
+		if !headSet && (r.HasState && r.HasMessages && r.HasReceipts) {
+			head = r
+			headSet = true
+		}
+		if r.HasState {
+			oldestStateRoot = r
+		}
+		if r.HasMessages {
+			oldestMessage = r
+		}
+	}
+
+	compiledReport := stateReport{
+		Detail: details,
+		Summary: summarizedHeights{
+			Messages:   stateHeights{Newest: head.Height, Oldest: oldestMessage.Height},
+			StateRoots: stateHeights{Newest: head.Height, Oldest: oldestStateRoot.Height},
+		},
+	}
+
+	reportOut, err := json.Marshal(compiledReport)
+	if err != nil {
+		return nil, err
+	}
+
+	return reportOut, nil
 }
 
-var ChainListStates = &cli.Command{
-	Name:  "list-state",
-	Usage: "List states and their completeness",
+var ChainStateInspect = &cli.Command{
+	Name:  "state-inspect",
+	Usage: "Returns details about each epoch's state in the local datastore",
 	Flags: []cli.Flag{
 		&cli.Uint64Flag{
-			Name:  "limit",
-			Value: 0,
+			Name:    "limit",
+			Aliases: []string{"l"},
+			Value:   100,
+			Usage:   "Limit traversal of statetree when searching for oldest state by `N` heights starting from most recent",
+		},
+		&cli.BoolFlag{
+			Name:    "verbose",
+			Aliases: []string{"v"},
+			Usage:   "Include detailed information about the completeness of state for all traversed height(s) starting from most recent",
+		},
+		&cli.BoolFlag{
+			Name:  "compact",
+			Usage: "Print JSON without whitespace",
 		},
 	},
 	Action: func(cctx *cli.Context) error {
@@ -113,68 +176,24 @@ var ChainListStates = &cli.Command{
 		sort.Slice(report, func(i, j int) bool {
 			return report[i].Height > report[j].Height
 		})
-		printReport(report)
-		return nil
-	},
-}
 
-var ChainFindOldestState = &cli.Command{
-	Name:  "find-oldest",
-	Usage: "Find the oldest full statetree",
-	Flags: []cli.Flag{
-		&cli.Uint64Flag{
-			Name:  "limit",
-			Value: 0,
-		},
-	},
-	Action: func(cctx *cli.Context) error {
-		ctx := lotuscli.ReqContext(cctx)
-		lapi, closer, err := GetAPI(ctx)
+		out, err := marshalReport(report, cctx.Bool("verbose"))
 		if err != nil {
 			return err
 		}
-		defer closer()
-
-		report, err := lapi.FindOldestState(ctx, cctx.Int64("limit"))
-		if err != nil {
-			return err
-		}
-		sort.Slice(report, func(i, j int) bool {
-			return report[i].Height > report[j].Height
-		})
-
-		head := report[0]
-		oldestStateRoot := &lily.StateReport{}
-		oldestMessage := &lily.StateReport{}
-		headSet := false
-		for _, r := range report {
-			if !headSet && (r.HasState && r.HasMessages && r.HasReceipts) {
-				head = r
-				headSet = true
-			}
-			if r.HasState {
-				oldestStateRoot = r
-			}
-			if r.HasMessages {
-				oldestMessage = r
-			}
-		}
-		fmt.Printf("Newest:\n")
-		fmt.Printf("\tStateRoot:\t%d\n", head.Height)
-		fmt.Printf("\tMessages:\t%d\n", head.Height)
-		fmt.Printf("Oldest:\n")
-		fmt.Printf("\tStateRoot:\t%d\n", oldestStateRoot.Height)
-		fmt.Printf("\tMessages:\t%d\n", oldestMessage.Height)
-
+		fmt.Println(string(out))
 		return nil
 	},
 }
 
 var ChainStateComputeRange = &cli.Command{
-	Name: "compute",
+	Name:  "state-compute",
+	Usage: "Generates the state at epoch `N`",
 	Flags: []cli.Flag{
 		&cli.Uint64Flag{
-			Name: "epoch",
+			Name:     "epoch",
+			Aliases:  []string{"e"},
+			Required: true,
 		},
 	},
 	Action: func(cctx *cli.Context) error {
@@ -201,13 +220,16 @@ var ChainStateComputeRange = &cli.Command{
 }
 
 var ChainStateCompute = &cli.Command{
-	Name: "compute-range",
+	Name:  "state-compute-range",
+	Usage: "Generates the state from epoch `FROM` to epoch `TO`",
 	Flags: []cli.Flag{
 		&cli.Uint64Flag{
-			Name: "from",
+			Name:     "from",
+			Required: true,
 		},
 		&cli.Uint64Flag{
-			Name: "to",
+			Name:     "to",
+			Required: true,
 		},
 	},
 	Action: func(cctx *cli.Context) error {

--- a/commands/chain.go
+++ b/commands/chain.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/urfave/cli/v2"
+	"gopkg.in/cheggaaa/pb.v1"
 
 	"github.com/filecoin-project/lily/chain/actors"
 	init_ "github.com/filecoin-project/lily/chain/actors/builtin/init"
@@ -42,6 +43,10 @@ var ChainCmd = &cli.Command{
 		ChainListCmd,
 		ChainSetHeadCmd,
 		ChainActorCodesCmd,
+		ChainFindOldestState,
+		ChainListStates,
+		ChainStateCompute,
+		ChainStateComputeRange,
 	},
 }
 
@@ -74,24 +79,170 @@ var ChainActorCodesCmd = &cli.Command{
 	},
 }
 
-func printSortedActorVersions(av map[actors.Version]cid.Cid) error {
+func printReport(r []*lily.StateReport) {
 	t := table.NewWriter()
-	t.AppendHeader(table.Row{"Version", "Name", "Family", "Code"})
-	var versions []int
-	for v := range av {
-		versions = append(versions, int(v))
-	}
-	sort.Ints(versions)
-	for _, v := range versions {
-		name, family, err := util.ActorNameAndFamilyFromCode(av[actors.Version(v)])
-		if err != nil {
-			return err
-		}
-		t.AppendRow(table.Row{v, name, family, av[actors.Version(v)]})
+	t.AppendHeader(table.Row{"Height", "StateTree", "Messages"})
+	for _, v := range r {
+		t.AppendRow(table.Row{v.Height, v.HasState, v.HasMessages})
 		t.AppendSeparator()
 	}
 	fmt.Println(t.Render())
-	return nil
+}
+
+var ChainListStates = &cli.Command{
+	Name:  "list-state",
+	Usage: "List states and their completeness",
+	Flags: []cli.Flag{
+		&cli.Uint64Flag{
+			Name:  "limit",
+			Value: 0,
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		ctx := lotuscli.ReqContext(cctx)
+		lapi, closer, err := GetAPI(ctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		report, err := lapi.FindOldestState(ctx, cctx.Int64("limit"))
+		if err != nil {
+			return err
+		}
+		sort.Slice(report, func(i, j int) bool {
+			return report[i].Height > report[j].Height
+		})
+		printReport(report)
+		return nil
+	},
+}
+
+var ChainFindOldestState = &cli.Command{
+	Name:  "find-oldest",
+	Usage: "Find the oldest full statetree",
+	Flags: []cli.Flag{
+		&cli.Uint64Flag{
+			Name:  "limit",
+			Value: 0,
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		ctx := lotuscli.ReqContext(cctx)
+		lapi, closer, err := GetAPI(ctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		report, err := lapi.FindOldestState(ctx, cctx.Int64("limit"))
+		if err != nil {
+			return err
+		}
+		sort.Slice(report, func(i, j int) bool {
+			return report[i].Height > report[j].Height
+		})
+
+		head := report[0]
+		oldestStateRoot := &lily.StateReport{}
+		oldestMessage := &lily.StateReport{}
+		headSet := false
+		for _, r := range report {
+			if !headSet && (r.HasState && r.HasMessages && r.HasReceipts) {
+				head = r
+				headSet = true
+			}
+			if r.HasState {
+				oldestStateRoot = r
+			}
+			if r.HasMessages {
+				oldestMessage = r
+			}
+		}
+		fmt.Printf("Newest:\n")
+		fmt.Printf("\tStateRoot:\t%d\n", head.Height)
+		fmt.Printf("\tMessages:\t%d\n", head.Height)
+		fmt.Printf("Oldest:\n")
+		fmt.Printf("\tStateRoot:\t%d\n", oldestStateRoot.Height)
+		fmt.Printf("\tMessages:\t%d\n", oldestMessage.Height)
+
+		return nil
+	},
+}
+
+var ChainStateComputeRange = &cli.Command{
+	Name: "compute",
+	Flags: []cli.Flag{
+		&cli.Uint64Flag{
+			Name: "epoch",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		ctx := lotuscli.ReqContext(cctx)
+		lapi, closer, err := GetAPI(ctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		head, err := lapi.ChainHead(ctx)
+		if err != nil {
+			return err
+		}
+		ts, err := lapi.ChainGetTipSetByHeight(ctx, abi.ChainEpoch(cctx.Uint64("epoch")), head.Key())
+		if err != nil {
+			return err
+		}
+
+		_, err = lapi.StateCompute(ctx, ts.Key())
+		return err
+
+	},
+}
+
+var ChainStateCompute = &cli.Command{
+	Name: "compute-range",
+	Flags: []cli.Flag{
+		&cli.Uint64Flag{
+			Name: "from",
+		},
+		&cli.Uint64Flag{
+			Name: "to",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		ctx := lotuscli.ReqContext(cctx)
+		lapi, closer, err := GetAPI(ctx)
+		if err != nil {
+			return err
+		}
+		defer closer()
+
+		head, err := lapi.ChainHead(ctx)
+		if err != nil {
+			return err
+		}
+		bar := pb.StartNew(int(cctx.Uint64("to") - cctx.Uint64("from")))
+		bar.ShowTimeLeft = true
+		bar.ShowPercent = true
+		bar.ShowSpeed = true
+		bar.Units = pb.U_NO
+		for i := cctx.Int64("from"); i <= cctx.Int64("to"); i++ {
+			ts, err := lapi.ChainGetTipSetByHeight(ctx, abi.ChainEpoch(i), head.Key())
+			if err != nil {
+				return err
+			}
+
+			_, err = lapi.StateCompute(ctx, ts.Key())
+			if err != nil {
+				return err
+			}
+			bar.Add(1)
+		}
+		bar.Finish()
+		return nil
+
+	},
 }
 
 var ChainHeadCmd = &cli.Command{
@@ -546,4 +697,24 @@ func parseTipSet(ctx context.Context, api lily.LilyAPI, vals []string) (*types.T
 	}
 
 	return types.NewTipSet(headers)
+}
+
+func printSortedActorVersions(av map[actors.Version]cid.Cid) error {
+	t := table.NewWriter()
+	t.AppendHeader(table.Row{"Version", "Name", "Family", "Code"})
+	var versions []int
+	for v := range av {
+		versions = append(versions, int(v))
+	}
+	sort.Ints(versions)
+	for _, v := range versions {
+		name, family, err := util.ActorNameAndFamilyFromCode(av[actors.Version(v)])
+		if err != nil {
+			return err
+		}
+		t.AppendRow(table.Row{v, name, family, av[actors.Version(v)]})
+		t.AppendSeparator()
+	}
+	fmt.Println(t.Render())
+	return nil
 }

--- a/lens/lily/api.go
+++ b/lens/lily/api.go
@@ -71,6 +71,9 @@ type LilyAPI interface {
 	NetPeerInfo(context.Context, peer.ID) (*api.ExtendedPeerInfo, error)
 
 	StartTipSetWorker(ctx context.Context, cfg *LilyTipSetWorkerConfig) (*schedule.JobSubmitResult, error)
+
+	FindOldestState(ctx context.Context, limit int64) ([]*StateReport, error)
+	StateCompute(ctx context.Context, tsk types.TipSetKey) (interface{}, error)
 }
 type LilyJobConfig struct {
 	// Name is the name of the job.

--- a/lens/lily/impl.go
+++ b/lens/lily/impl.go
@@ -648,6 +648,7 @@ func (m *LilyNodeAPI) FindOldestState(ctx context.Context, limit int64) ([]*Stat
 	}
 
 	var out []*StateReport
+	var oldestEpochLimit = head.Height() - abi.ChainEpoch(limit)
 
 	for i := int64(0); true; i++ {
 		maybeBaseTS, err := m.ChainGetTipSetByHeight(ctx, head.Height()-abi.ChainEpoch(i), head.Key())
@@ -663,7 +664,7 @@ func (m *LilyNodeAPI) FindOldestState(ctx context.Context, limit int64) ([]*Stat
 			HasReceipts: maybeFullTS.HasReceipts,
 			HasState:    maybeFullTS.HasState,
 		})
-		if !maybeFullTS.HasState || int64(head.Height()-abi.ChainEpoch(i)) == limit {
+		if (head.Height() - abi.ChainEpoch(i)) <= oldestEpochLimit {
 			break
 		}
 	}

--- a/lens/lily/struct.go
+++ b/lens/lily/struct.go
@@ -77,7 +77,18 @@ type LilyAPIStruct struct {
 		NetPeerInfo      func(context.Context, peer.ID) (*api.ExtendedPeerInfo, error) `perm:"read"`
 
 		StartTipSetWorker func(ctx context.Context, cfg *LilyTipSetWorkerConfig) (*schedule.JobSubmitResult, error) `perm:"read"`
+
+		FindOldestState func(ctx context.Context, limit int64) ([]*StateReport, error)      `perm:"read"`
+		StateCompute    func(ctx context.Context, tsk types.TipSetKey) (interface{}, error) `perm:"read"`
 	}
+}
+
+func (s *LilyAPIStruct) StateCompute(ctx context.Context, tsk types.TipSetKey) (interface{}, error) {
+	return s.Internal.StateCompute(ctx, tsk)
+}
+
+func (s *LilyAPIStruct) FindOldestState(ctx context.Context, limit int64) ([]*StateReport, error) {
+	return s.Internal.FindOldestState(ctx, limit)
 }
 
 func (s *LilyAPIStruct) ChainGetTipSetAfterHeight(ctx context.Context, epoch abi.ChainEpoch, key types.TipSetKey) (*types.TipSet, error) {


### PR DESCRIPTION
### What
This PR adds 4 new commands to the chain command.

#### find oldest
Finds the range of states lily has a complete state tree for:
```
$ lily chain find-oldest
Newest:
	StateRoot:	1830000
	Messages:	1830000
Oldest:
	StateRoot:	1828199
	Messages:	1828199
```

#### list states
Lists all states lily has and their completeness:
``` 
$ lily chain list-state --limit=1829989
+---------+-----------+----------+
|  HEIGHT | STATETREE | MESSAGES |
+---------+-----------+----------+
| 1830000 | true      | true     |
+---------+-----------+----------+
| 1829999 | true      | true     |
+---------+-----------+----------+
| 1829998 | true      | true     |
+---------+-----------+----------+
| 1829997 | true      | true     |
+---------+-----------+----------+
| 1829996 | true      | true     |
+---------+-----------+----------+
| 1829995 | true      | true     |
+---------+-----------+----------+
| 1829994 | true      | true     |
+---------+-----------+----------+
| 1829993 | true      | true     |
+---------+-----------+----------+
| 1829992 | true      | true     |
+---------+-----------+----------+
| 1829991 | true      | true     |
+---------+-----------+----------+
| 1829990 | true      | true     |
+---------+-----------+----------+
| 1829989 | true      | true     |
+---------+-----------+----------+
```

#### compute
compute the state of a tipset specified by epoch:
```
$ lily chain compute --epoch=1829776
```

#### compute range
computes a range of tipsets specified by epochs:
```
$ lily chain compute-range --to=1829981 --from=1829777
```
