### PR TITLE
Replace ExecutedAndBlockMessages with individual methods

### DIFF
--- a/chain/datasource/datasource.go
+++ b/chain/datasource/datasource.go
@@ -278,7 +278,7 @@ func (t *DataSource) MinerLoad(store adt.Store, act *types.Actor) (miner.State, 
 	return miner.Load(store, act)
 }
 
-func (t *DataSource) ShouldBrunFn(ctx context.Context, ts *types.TipSet) (lens.ShouldBurnFn, error) {
+func (t *DataSource) ShouldBurnFn(ctx context.Context, ts *types.TipSet) (lens.ShouldBurnFn, error) {
 	return t.node.BurnFundsFn(ctx, ts)
 }
 

--- a/chain/datasource/datasource.go
+++ b/chain/datasource/datasource.go
@@ -108,6 +108,14 @@ type DataSource struct {
 	diffPreCommitGroup singleflight.Group
 }
 
+func (t *DataSource) TipSetBlockMessages(ctx context.Context, ts *types.TipSet) ([]*lens.BlockMessages, error) {
+	return t.node.MessagesForTipSetBlocks(ctx, ts)
+}
+
+func (t *DataSource) TipSetMessages(ctx context.Context, ts *types.TipSet) ([]types.ChainMsg, error) {
+	return t.node.MessagesForTipSet(ctx, ts)
+}
+
 func NewDataSource(node lens.API) (*DataSource, error) {
 	t := &DataSource{
 		node: node,

--- a/chain/indexer/integrated/processor/state.go
+++ b/chain/indexer/integrated/processor/state.go
@@ -541,11 +541,12 @@ func MakeProcessors(api tasks.DataSource, indexerTasks []string) (*IndexerProces
 			// Messages
 			//
 		case tasktype.Message:
-			out.TipsetsProcessors[t] = messagetask.NewTask(api)
+			out.TipsetProcessors[t] = messagetask.NewTask(api)
+		case tasktype.BlockMessage:
+			out.TipsetProcessors[t] = bmtask.NewTask(api)
+
 		case tasktype.GasOutputs:
 			out.TipsetsProcessors[t] = gasouttask.NewTask(api)
-		case tasktype.BlockMessage:
-			out.TipsetsProcessors[t] = bmtask.NewTask(api)
 		case tasktype.ParsedMessage:
 			out.TipsetsProcessors[t] = parentmessagetask.NewTask(api)
 		case tasktype.Receipt:

--- a/chain/indexer/integrated/processor/state.go
+++ b/chain/indexer/integrated/processor/state.go
@@ -544,6 +544,8 @@ func MakeProcessors(api tasks.DataSource, indexerTasks []string) (*IndexerProces
 			out.TipsetProcessors[t] = messagetask.NewTask(api)
 		case tasktype.BlockMessage:
 			out.TipsetProcessors[t] = bmtask.NewTask(api)
+		case tasktype.MessageGasEconomy:
+			out.TipsetProcessors[t] = gasecontask.NewTask(api)
 
 		case tasktype.GasOutputs:
 			out.TipsetsProcessors[t] = gasouttask.NewTask(api)
@@ -555,8 +557,6 @@ func MakeProcessors(api tasks.DataSource, indexerTasks []string) (*IndexerProces
 			out.TipsetsProcessors[t] = imtask.NewTask(api)
 		case tasktype.InternalParsedMessage:
 			out.TipsetsProcessors[t] = ipmtask.NewTask(api)
-		case tasktype.MessageGasEconomy:
-			out.TipsetsProcessors[t] = gasecontask.NewTask(api)
 		case tasktype.MultisigApproval:
 			out.TipsetsProcessors[t] = msapprovaltask.NewTask(api)
 		case tasktype.VmMessage:

--- a/chain/indexer/integrated/processor/state_internal_test.go
+++ b/chain/indexer/integrated/processor/state_internal_test.go
@@ -16,6 +16,9 @@ import (
 	"github.com/filecoin-project/lily/chain/actors/builtin/verifreg"
 	"github.com/filecoin-project/lily/chain/indexer/tasktype"
 	"github.com/filecoin-project/lily/tasks/messageexecutions/vm"
+	"github.com/filecoin-project/lily/tasks/messages/blockmessage"
+	"github.com/filecoin-project/lily/tasks/messages/gaseconomy"
+	"github.com/filecoin-project/lily/tasks/messages/message"
 
 	"github.com/filecoin-project/lily/tasks/actorstate"
 	inittask "github.com/filecoin-project/lily/tasks/actorstate/init_"
@@ -34,10 +37,7 @@ import (
 	"github.com/filecoin-project/lily/tasks/consensus"
 	"github.com/filecoin-project/lily/tasks/messageexecutions/internalmessage"
 	"github.com/filecoin-project/lily/tasks/messageexecutions/internalparsedmessage"
-	"github.com/filecoin-project/lily/tasks/messages/blockmessage"
-	"github.com/filecoin-project/lily/tasks/messages/gaseconomy"
 	"github.com/filecoin-project/lily/tasks/messages/gasoutput"
-	"github.com/filecoin-project/lily/tasks/messages/message"
 	"github.com/filecoin-project/lily/tasks/messages/parsedmessage"
 	"github.com/filecoin-project/lily/tasks/messages/receipt"
 	"github.com/filecoin-project/lily/tasks/msapprovals"
@@ -48,26 +48,26 @@ func TestNewProcessor(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, t.Name(), proc.name)
 	require.Len(t, proc.actorProcessors, 21)
-	require.Len(t, proc.tipsetProcessors, 5)
-	require.Len(t, proc.tipsetsProcessors, 10)
+	require.Len(t, proc.tipsetProcessors, 8)
+	require.Len(t, proc.tipsetsProcessors, 7)
 	require.Len(t, proc.builtinProcessors, 1)
 
-	require.Equal(t, message.NewTask(nil), proc.tipsetsProcessors[tasktype.Message])
 	require.Equal(t, gasoutput.NewTask(nil), proc.tipsetsProcessors[tasktype.GasOutputs])
-	require.Equal(t, blockmessage.NewTask(nil), proc.tipsetsProcessors[tasktype.BlockMessage])
 	require.Equal(t, parsedmessage.NewTask(nil), proc.tipsetsProcessors[tasktype.ParsedMessage])
 	require.Equal(t, receipt.NewTask(nil), proc.tipsetsProcessors[tasktype.Receipt])
 	require.Equal(t, internalmessage.NewTask(nil), proc.tipsetsProcessors[tasktype.InternalMessage])
 	require.Equal(t, internalparsedmessage.NewTask(nil), proc.tipsetsProcessors[tasktype.InternalParsedMessage])
-	require.Equal(t, gaseconomy.NewTask(nil), proc.tipsetsProcessors[tasktype.MessageGasEconomy])
 	require.Equal(t, msapprovals.NewTask(nil), proc.tipsetsProcessors[tasktype.MultisigApproval])
 	require.Equal(t, vm.NewTask(nil), proc.tipsetsProcessors[tasktype.VmMessage])
 
+	require.Equal(t, message.NewTask(nil), proc.tipsetProcessors[tasktype.Message])
+	require.Equal(t, blockmessage.NewTask(nil), proc.tipsetProcessors[tasktype.BlockMessage])
 	require.Equal(t, headers.NewTask(), proc.tipsetProcessors[tasktype.BlockHeader])
 	require.Equal(t, parents.NewTask(), proc.tipsetProcessors[tasktype.BlockParent])
 	require.Equal(t, drand.NewTask(), proc.tipsetProcessors[tasktype.DrandBlockEntrie])
 	require.Equal(t, chaineconomics.NewTask(nil), proc.tipsetProcessors[tasktype.ChainEconomics])
 	require.Equal(t, consensus.NewTask(nil), proc.tipsetProcessors[tasktype.ChainConsensus])
+	require.Equal(t, gaseconomy.NewTask(nil), proc.tipsetProcessors[tasktype.MessageGasEconomy])
 
 	require.Equal(t, actorstate.NewTask(nil, actorstate.NewTypedActorExtractorMap(miner.AllCodes(), minertask.DeadlineInfoExtractor{})), proc.actorProcessors[tasktype.MinerCurrentDeadlineInfo])
 	require.Equal(t, actorstate.NewTask(nil, actorstate.NewTypedActorExtractorMap(miner.AllCodes(), minertask.FeeDebtExtractor{})), proc.actorProcessors[tasktype.MinerFeeDebt])

--- a/chain/indexer/integrated/processor/state_test.go
+++ b/chain/indexer/integrated/processor/state_test.go
@@ -269,47 +269,47 @@ func TestMakeProcessorsActors(t *testing.T) {
 
 func TestMakeProcessorsTipSet(t *testing.T) {
 	tasks := []string{
+		tasktype.Message,
+		tasktype.BlockMessage,
 		tasktype.BlockHeader,
 		tasktype.BlockParent,
 		tasktype.DrandBlockEntrie,
 		tasktype.ChainEconomics,
 		tasktype.ChainConsensus,
+		tasktype.MessageGasEconomy,
 	}
 	proc, err := processor.MakeProcessors(nil, tasks)
 	require.NoError(t, err)
 	require.Len(t, proc.TipsetProcessors, len(tasks))
 
+	require.Equal(t, message.NewTask(nil), proc.TipsetProcessors[tasktype.Message])
+	require.Equal(t, blockmessage.NewTask(nil), proc.TipsetProcessors[tasktype.BlockMessage])
 	require.Equal(t, headers.NewTask(), proc.TipsetProcessors[tasktype.BlockHeader])
 	require.Equal(t, parents.NewTask(), proc.TipsetProcessors[tasktype.BlockParent])
 	require.Equal(t, drand.NewTask(), proc.TipsetProcessors[tasktype.DrandBlockEntrie])
 	require.Equal(t, chaineconomics.NewTask(nil), proc.TipsetProcessors[tasktype.ChainEconomics])
 	require.Equal(t, consensus.NewTask(nil), proc.TipsetProcessors[tasktype.ChainConsensus])
+	require.Equal(t, gaseconomy.NewTask(nil), proc.TipsetProcessors[tasktype.MessageGasEconomy])
 }
 
 func TestMakeProcessorsTipSets(t *testing.T) {
 	tasks := []string{
-		tasktype.Message,
 		tasktype.GasOutputs,
-		tasktype.BlockMessage,
 		tasktype.ParsedMessage,
 		tasktype.Receipt,
 		tasktype.InternalMessage,
 		tasktype.InternalParsedMessage,
-		tasktype.MessageGasEconomy,
 		tasktype.MultisigApproval,
 	}
 	proc, err := processor.MakeProcessors(nil, tasks)
 	require.NoError(t, err)
 	require.Len(t, proc.TipsetsProcessors, len(tasks))
 
-	require.Equal(t, message.NewTask(nil), proc.TipsetsProcessors[tasktype.Message])
 	require.Equal(t, gasoutput.NewTask(nil), proc.TipsetsProcessors[tasktype.GasOutputs])
-	require.Equal(t, blockmessage.NewTask(nil), proc.TipsetsProcessors[tasktype.BlockMessage])
 	require.Equal(t, parsedmessage.NewTask(nil), proc.TipsetsProcessors[tasktype.ParsedMessage])
 	require.Equal(t, receipt.NewTask(nil), proc.TipsetsProcessors[tasktype.Receipt])
 	require.Equal(t, internalmessage.NewTask(nil), proc.TipsetsProcessors[tasktype.InternalMessage])
 	require.Equal(t, internalparsedmessage.NewTask(nil), proc.TipsetsProcessors[tasktype.InternalParsedMessage])
-	require.Equal(t, gaseconomy.NewTask(nil), proc.TipsetsProcessors[tasktype.MessageGasEconomy])
 	require.Equal(t, msapprovals.NewTask(nil), proc.TipsetsProcessors[tasktype.MultisigApproval])
 }
 
@@ -346,7 +346,7 @@ func TestMakeProcessorsAllTasks(t *testing.T) {
 	proc, err := processor.MakeProcessors(nil, append(tasktype.AllTableTasks, processor.BuiltinTaskName))
 	require.NoError(t, err)
 	require.Len(t, proc.ActorProcessors, 21)
-	require.Len(t, proc.TipsetProcessors, 5)
-	require.Len(t, proc.TipsetsProcessors, 10)
+	require.Len(t, proc.TipsetProcessors, 8)
+	require.Len(t, proc.TipsetsProcessors, 7)
 	require.Len(t, proc.ReportProcessors, 1)
 }

--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	github.com/filecoin-project/specs-actors/v8 v8.0.1
 	github.com/hibiken/asynq v0.23.0
 	github.com/hibiken/asynq/x v0.0.0-20220413130846-5c723f597e01
+	github.com/ipfs/go-ipld-format v0.4.0
 	github.com/jedib0t/go-pretty/v6 v6.2.7
 	go.opentelemetry.io/otel/trace v1.3.0
 	go.uber.org/atomic v1.9.0
@@ -196,7 +197,6 @@ require (
 	github.com/ipfs/go-ipfs-pq v0.0.2 // indirect
 	github.com/ipfs/go-ipfs-routing v0.2.1 // indirect
 	github.com/ipfs/go-ipfs-util v0.0.2 // indirect
-	github.com/ipfs/go-ipld-format v0.4.0 // indirect
 	github.com/ipfs/go-ipld-legacy v0.1.1 // indirect
 	github.com/ipfs/go-ipns v0.1.2 // indirect
 	github.com/ipfs/go-log v1.0.5 // indirect

--- a/lens/interface.go
+++ b/lens/interface.go
@@ -42,6 +42,9 @@ type ChainAPI interface {
 	ChainGetBlockMessages(ctx context.Context, msg cid.Cid) (*api.BlockMessages, error)
 	ChainGetParentMessages(ctx context.Context, blockCid cid.Cid) ([]api.Message, error)
 	ChainGetParentReceipts(ctx context.Context, blockCid cid.Cid) ([]*types.MessageReceipt, error)
+
+	MessagesForTipSet(ctx context.Context, ts *types.TipSet) ([]types.ChainMsg, error)
+	MessagesForTipSetBlocks(ctx context.Context, ts *types.TipSet) ([]*BlockMessages, error)
 }
 
 type StateAPI interface {
@@ -61,7 +64,6 @@ type StateAPI interface {
 
 type TipSetMessages struct {
 	Executed []*ExecutedMessage
-	Block    []*BlockMessages
 }
 
 type MessageExecution struct {

--- a/lens/interface.go
+++ b/lens/interface.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 
@@ -20,6 +21,7 @@ type API interface {
 	StoreAPI
 	ChainAPI
 	StateAPI
+	VMAPI
 
 	GetExecutedAndBlockMessagesForTipset(ctx context.Context, ts, pts *types.TipSet) (*TipSetMessages, error)
 	GetMessageExecutionsForTipSet(ctx context.Context, ts, pts *types.TipSet) ([]*MessageExecution, error)
@@ -67,6 +69,11 @@ type StateAPI interface {
 	StateGetReceipt(ctx context.Context, bcid cid.Cid, tsk types.TipSetKey) (*types.MessageReceipt, error)
 	CirculatingSupply(context.Context, types.TipSetKey) (api.CirculatingSupply, error)
 	StateNetworkName(context.Context) (dtypes.NetworkName, error)
+}
+
+type ShouldBurnFn func(ctx context.Context, msg *types.Message, errcode exitcode.ExitCode) (bool, error)
+type VMAPI interface {
+	BurnFundsFn(ctx context.Context, ts, pts *types.TipSet) (ShouldBurnFn, error)
 }
 
 type TipSetMessages struct {

--- a/lens/interface.go
+++ b/lens/interface.go
@@ -3,6 +3,7 @@ package lens
 import (
 	"context"
 
+	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 
 	"github.com/filecoin-project/go-address"
@@ -41,8 +42,12 @@ type ChainAPI interface {
 
 	ChainGetBlockMessages(ctx context.Context, msg cid.Cid) (*api.BlockMessages, error)
 	ChainGetParentMessages(ctx context.Context, blockCid cid.Cid) ([]api.Message, error)
-	ChainGetParentReceipts(ctx context.Context, blockCid cid.Cid) ([]*types.MessageReceipt, error)
 
+	BlockMessageForTipSet(ctx context.Context, ts *types.TipSet) ([]store.BlockMessages, error)
+
+	GetParentReceipt(ctx context.Context, b *types.BlockHeader, i int) (*types.MessageReceipt, error)
+
+	MessagesForBlock(ctx context.Context, b *types.BlockHeader) ([]*types.Message, []*types.SignedMessage, error)
 	MessagesForTipSet(ctx context.Context, ts *types.TipSet) ([]types.ChainMsg, error)
 	MessagesForTipSetBlocks(ctx context.Context, ts *types.TipSet) ([]*BlockMessages, error)
 }
@@ -87,7 +92,7 @@ type ExecutedMessage struct {
 	Receipt       *types.MessageReceipt
 	BlockHeader   *types.BlockHeader
 	Blocks        []cid.Cid // blocks this message appeared in
-	Index         uint64    // Message and receipt sequence in tipset
+	Index         uint64    // Message and Receipt sequence in tipset
 	FromActorCode cid.Cid   // code of the actor the message is from
 	ToActorCode   cid.Cid   // code of the actor the message is to
 	GasOutputs    vm.GasOutputs

--- a/lens/lily/impl.go
+++ b/lens/lily/impl.go
@@ -62,6 +62,26 @@ type LilyNodeAPI struct {
 	actorStoreInit sync.Once
 }
 
+func (m *LilyNodeAPI) MessagesForTipSetBlocks(ctx context.Context, ts *types.TipSet) ([]*lens.BlockMessages, error) {
+	var out []*lens.BlockMessages
+	for _, blk := range ts.Blocks() {
+		blkMsgs, err := m.ChainAPI.ChainModuleAPI.ChainGetBlockMessages(ctx, blk.Cid())
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, &lens.BlockMessages{
+			Block:        blk,
+			BlsMessages:  blkMsgs.BlsMessages,
+			SecpMessages: blkMsgs.SecpkMessages,
+		})
+	}
+	return out, nil
+}
+
+func (m *LilyNodeAPI) MessagesForTipSet(ctx context.Context, ts *types.TipSet) ([]types.ChainMsg, error) {
+	return m.ChainAPI.Chain.MessagesForTipset(ctx, ts)
+}
+
 func (m *LilyNodeAPI) CirculatingSupply(ctx context.Context, key types.TipSetKey) (api.CirculatingSupply, error) {
 	return m.StateAPI.StateVMCirculatingSupplyInternal(ctx, key)
 }

--- a/lens/lily/impl.go
+++ b/lens/lily/impl.go
@@ -10,6 +10,7 @@ import (
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/events"
 	"github.com/filecoin-project/lotus/chain/stmgr"
+	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/node/impl/common"
 	"github.com/filecoin-project/lotus/node/impl/full"
@@ -60,6 +61,19 @@ type LilyNodeAPI struct {
 
 	actorStore     adt.Store
 	actorStoreInit sync.Once
+}
+
+func (m *LilyNodeAPI) GetParentReceipt(ctx context.Context, b *types.BlockHeader, i int) (*types.MessageReceipt, error) {
+	return m.ChainAPI.Chain.GetParentReceipt(ctx, b, i)
+}
+
+func (m *LilyNodeAPI) MessagesForBlock(ctx context.Context, b *types.BlockHeader) ([]*types.Message, []*types.SignedMessage, error) {
+	return m.ChainAPI.Chain.MessagesForBlock(ctx, b)
+}
+
+// returned BlockMessages match block order in tipset, use this for receipt stuufs
+func (m *LilyNodeAPI) BlockMessageForTipSet(ctx context.Context, ts *types.TipSet) ([]store.BlockMessages, error) {
+	return m.ChainAPI.Chain.BlockMsgsForTipset(ctx, ts)
 }
 
 func (m *LilyNodeAPI) MessagesForTipSetBlocks(ctx context.Context, ts *types.TipSet) ([]*lens.BlockMessages, error) {

--- a/lens/lily/impl.go
+++ b/lens/lily/impl.go
@@ -14,7 +14,6 @@ import (
 	"github.com/filecoin-project/lotus/chain/events"
 	"github.com/filecoin-project/lotus/chain/state"
 	"github.com/filecoin-project/lotus/chain/stmgr"
-	"github.com/filecoin-project/lotus/chain/store"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/vm"
 	"github.com/filecoin-project/lotus/node/impl/common"
@@ -23,6 +22,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/util/adt"
 	"github.com/go-pg/pg/v10"
 	"github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
 	logging "github.com/ipfs/go-log/v2"
 	"go.uber.org/fx"
 
@@ -68,166 +68,9 @@ type LilyNodeAPI struct {
 	actorStoreInit sync.Once
 }
 
-func (m *LilyNodeAPI) GetParentReceipt(ctx context.Context, b *types.BlockHeader, i int) (*types.MessageReceipt, error) {
-	return m.ChainAPI.Chain.GetParentReceipt(ctx, b, i)
-}
-
-func (m *LilyNodeAPI) MessagesForBlock(ctx context.Context, b *types.BlockHeader) ([]*types.Message, []*types.SignedMessage, error) {
-	return m.ChainAPI.Chain.MessagesForBlock(ctx, b)
-}
-
-// BlockMessageForTipSet returned BlockMessages match block order in tipset, use this for receipt stuufs
-func (m *LilyNodeAPI) BlockMessageForTipSet(ctx context.Context, ts *types.TipSet) ([]store.BlockMessages, error) {
-	return m.ChainAPI.Chain.BlockMsgsForTipset(ctx, ts)
-}
-
-func (m *LilyNodeAPI) MessagesForTipSetBlocks(ctx context.Context, ts *types.TipSet) ([]*lens.BlockMessages, error) {
-	var out []*lens.BlockMessages
-	for _, blk := range ts.Blocks() {
-		blkMsgs, err := m.ChainAPI.ChainModuleAPI.ChainGetBlockMessages(ctx, blk.Cid())
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, &lens.BlockMessages{
-			Block:        blk,
-			BlsMessages:  blkMsgs.BlsMessages,
-			SecpMessages: blkMsgs.SecpkMessages,
-		})
-	}
-	return out, nil
-}
-
-func (m *LilyNodeAPI) MessagesForTipSet(ctx context.Context, ts *types.TipSet) ([]types.ChainMsg, error) {
-	return m.ChainAPI.Chain.MessagesForTipset(ctx, ts)
-}
-
-// TipSetMessageReceipts returns the blocks and messages in `ts` and their corresponding receipts from `pts` matching block order in tipset (`ts`).
-func (m *LilyNodeAPI) TipSetMessageReceipts(ctx context.Context, ts, pts *types.TipSet) ([]*lens.BlockMessageReceipts, error) {
-	// retrieve receipts using a block from the child (ts) tipset
-	// TODO this operation can fail when the node is imported from a snapshot that does not contain receipts (most don't)
-	// the solution is to compute the tipset state which will create the receipts we load here
-	rs, err := adt.AsArray(m.Store(), ts.Blocks()[0].ParentMessageReceipts)
-	if err != nil {
-		return nil, err
-	}
-	// so we only load the receipt array one
-	getReceipt := func(idx int) (*types.MessageReceipt, error) {
-		var r types.MessageReceipt
-		if found, err := rs.Get(uint64(idx), &r); err != nil {
-			return nil, err
-		} else if !found {
-			return nil, fmt.Errorf("failed to find receipt %d", idx)
-		}
-		return &r, nil
-	}
-
-	// returned BlockMessages match block order in tipset
-	blkMsgs, err := m.BlockMessageForTipSet(ctx, pts)
-	if err != nil {
-		return nil, err
-	}
-	if len(blkMsgs) != len(pts.Blocks()) {
-		// logic error somewhere
-		return nil, fmt.Errorf("mismatching number of blocks returned from block messages, got %d wanted %d", len(blkMsgs), len(pts.Blocks()))
-	}
-
-	out := make([]*lens.BlockMessageReceipts, len(pts.Blocks()))
-	// walk each block in tipset, `pts.Blocks()` has same ordering as `blkMsgs`.
-	for blkIdx := range pts.Blocks() {
-		// bls and secp messages for block
-		msgs := blkMsgs[blkIdx]
-		// index of messages in `out.Messages`
-		msgIdx := 0
-		// index or receipts in `out.Receipts`
-		receiptIdx := 0
-		// block containing messages
-		out[blkIdx].Block = pts.Blocks()[blkIdx]
-		// total messages returned equal to sum of bls and secp messages
-		out[blkIdx].Message = make([]*types.Message, len(msgs.BlsMessages)+len(msgs.SecpkMessages))
-		// total receipts returned equal to sum of bls and secp messages
-		out[blkIdx].Receipt = make([]*types.MessageReceipt, len(msgs.BlsMessages)+len(msgs.SecpkMessages))
-		// walk bls messages and extract their receipts
-		for blsIdx := range msgs.BlsMessages {
-			receipt, err := getReceipt(receiptIdx)
-			if err != nil {
-				return nil, err
-			}
-			out[blkIdx].Message[msgIdx] = msgs.BlsMessages[blsIdx].VMMessage()
-			out[blkIdx].Receipt[receiptIdx] = receipt
-			msgIdx++
-			receiptIdx++
-		}
-		// walk secp messages and extract their receipts
-		for secpIdx := range msgs.SecpkMessages {
-			receipt, err := getReceipt(receiptIdx)
-			if err != nil {
-				return nil, err
-			}
-			out[blkIdx].Message[msgIdx] = msgs.SecpkMessages[secpIdx].VMMessage()
-			out[blkIdx].Receipt[receiptIdx] = receipt
-			msgIdx++
-			receiptIdx++
-		}
-	}
-	return out, nil
-}
-
 type vmWrapper struct {
 	vm vm.Interface
 	st *state.StateTree
-}
-
-func (v *vmWrapper) ShouldBurn(ctx context.Context, msg *types.Message, errcode exitcode.ExitCode) (bool, error) {
-	if lvmi, ok := v.vm.(*vm.LegacyVM); ok {
-		return lvmi.ShouldBurn(ctx, v.st, msg, errcode)
-	}
-
-	// Any "don't burn" rules from Network v13 onwards go here, for now we always return true
-	// source: https://github.com/filecoin-project/lotus/blob/v1.15.1/chain/vm/vm.go#L647
-	return true, nil
-}
-
-func (m *LilyNodeAPI) BurnFundsFn(ctx context.Context, ts, pts *types.TipSet) (lens.ShouldBurnFn, error) {
-	// Create a skeleton vm just for calling ShouldBurn
-	// NB: VM is only required to process state prior to network v13
-	if util.DefaultNetwork.Version(ctx, pts.Height()) <= network2.Version12 {
-		vmi, err := vm.NewVM(ctx, &vm.VMOpts{
-			StateBase:      ts.ParentState(),
-			Epoch:          ts.Height(),
-			Bstore:         m.ChainAPI.Chain.StateBlockstore(),
-			Actors:         filcns.NewActorRegistry(),
-			Syscalls:       m.StateManager.Syscalls,
-			CircSupplyCalc: m.StateManager.GetVMCirculatingSupply,
-			NetworkVersion: util.DefaultNetwork.Version(ctx, ts.Height()),
-			BaseFee:        ts.Blocks()[0].ParentBaseFee,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("creating temporary vm: %w", err)
-		}
-		parentStateTree, err := state.LoadStateTree(m.ChainAPI.Chain.ActorStore(ctx), pts.ParentState())
-		if err != nil {
-			return nil, err
-		}
-		vmw := &vmWrapper{vm: vmi, st: parentStateTree}
-		return vmw.ShouldBurn, nil
-	}
-	// always burn after Network Verions 12
-	return func(ctx context.Context, msg *types.Message, errcode exitcode.ExitCode) (bool, error) {
-		return true, nil
-	}, nil
-}
-
-func (m *LilyNodeAPI) CirculatingSupply(ctx context.Context, key types.TipSetKey) (api.CirculatingSupply, error) {
-	return m.StateAPI.StateVMCirculatingSupplyInternal(ctx, key)
-}
-
-func (m *LilyNodeAPI) ChainGetTipSetAfterHeight(ctx context.Context, epoch abi.ChainEpoch, key types.TipSetKey) (*types.TipSet, error) {
-	// TODO (Frrist): I copied this from lotus, I need it now to handle gap filling edge cases.
-	ts, err := m.ChainAPI.Chain.GetTipSetFromKey(ctx, key)
-	if err != nil {
-		return nil, fmt.Errorf("loading tipset %s: %w", key, err)
-	}
-	return m.ChainAPI.Chain.GetTipsetByHeight(ctx, epoch, ts, false)
 }
 
 func (m *LilyNodeAPI) StartTipSetWorker(_ context.Context, cfg *LilyTipSetWorkerConfig) (*schedule.JobSubmitResult, error) {
@@ -636,10 +479,6 @@ func (m *LilyNodeAPI) LilyJobList(_ context.Context) ([]schedule.JobListResult, 
 	return m.Scheduler.Jobs(), nil
 }
 
-func (m *LilyNodeAPI) GetExecutedAndBlockMessagesForTipset(ctx context.Context, ts, pts *types.TipSet) (*lens.TipSetMessages, error) {
-	return util.GetExecutedAndBlockMessagesForTipset(ctx, m.ChainAPI.Chain, m.StateManager, ts, pts)
-}
-
 func (m *LilyNodeAPI) GetMessageExecutionsForTipSet(ctx context.Context, next *types.TipSet, current *types.TipSet) ([]*lens.MessageExecution, error) {
 	// this is defined in the lily daemon dep injection constructor, failure here is a developer error.
 	msgMonitor, ok := m.ExecMonitor.(*modules.BufferedExecMonitor)
@@ -697,6 +536,179 @@ func (m *LilyNodeAPI) GetMessageExecutionsForTipSet(ctx context.Context, next *t
 		}
 	}
 	return out, nil
+}
+
+// ComputeBaseFee calculates the base-fee of the specified tipset.
+func (m *LilyNodeAPI) ComputeBaseFee(ctx context.Context, ts *types.TipSet) (abi.TokenAmount, error) {
+	return m.ChainAPI.Chain.ComputeBaseFee(ctx, ts)
+}
+
+// MessagesForTipSetBlocks returns messages stored in the blocks of the specified tipset, messages may be duplicated
+// across the returned set of BlockMessages.
+func (m *LilyNodeAPI) MessagesForTipSetBlocks(ctx context.Context, ts *types.TipSet) ([]*lens.BlockMessages, error) {
+	var out []*lens.BlockMessages
+	for _, blk := range ts.Blocks() {
+		blkMsgs, err := m.ChainAPI.ChainModuleAPI.ChainGetBlockMessages(ctx, blk.Cid())
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, &lens.BlockMessages{
+			Block:        blk,
+			BlsMessages:  blkMsgs.BlsMessages,
+			SecpMessages: blkMsgs.SecpkMessages,
+		})
+	}
+	return out, nil
+}
+
+// TipSetMessageReceipts returns the blocks and messages in `pts` and their corresponding receipts from `ts` matching block order in tipset (`pts`).
+func (m *LilyNodeAPI) TipSetMessageReceipts(ctx context.Context, ts, pts *types.TipSet) ([]*lens.BlockMessageReceipts, error) {
+	// returned BlockMessages match block order in tipset
+	blkMsgs, err := m.ChainAPI.Chain.BlockMsgsForTipset(ctx, pts)
+	if err != nil {
+		return nil, err
+	}
+	if len(blkMsgs) != len(pts.Blocks()) {
+		// logic error somewhere
+		return nil, fmt.Errorf("mismatching number of blocks returned from block messages, got %d wanted %d", len(blkMsgs), len(pts.Blocks()))
+	}
+
+	// retrieve receipts using a block from the child (ts) tipset
+	rs, err := adt.AsArray(m.Store(), ts.Blocks()[0].ParentMessageReceipts)
+	if err != nil {
+		// if we fail to find the receipts then we need to compute them, which we can safely do since the above `BlockMsgsForTipset` call
+		// returning successfully indicates we have the message available to compute receipts from.
+		if ipld.IsNotFound(err) {
+			log.Debugw("computing tipset to get receipts", "ts", pts.Key().String(), "height", pts.Height())
+			if stateRoot, receiptRoot, err := m.StateManager.TipSetState(ctx, pts); err != nil {
+				log.Errorw("failed to compute tipset state", "tipset", pts.Key().String(), "height", pts.Height())
+				return nil, err
+			} else if !stateRoot.Equals(ts.ParentState()) { // sanity check
+				return nil, fmt.Errorf("computed stateroot (%s) does not match tipset stateroot (%s)", stateRoot.String(), ts.ParentState().String())
+			} else if !receiptRoot.Equals(ts.Blocks()[0].ParentMessageReceipts) { // sanity check
+				return nil, fmt.Errorf("computed receipts (%s) does not match tipset block parent message receipts (%s)", receiptRoot.String(), ts.Blocks()[0].ParentMessageReceipts.String())
+			}
+			// loading after computing state should succeed as tipset computation produces message receipts
+			rs, err = adt.AsArray(m.Store(), ts.Blocks()[0].ParentMessageReceipts)
+			if err != nil {
+				return nil, fmt.Errorf("load message receipts after tipset execution (something if very wrong contact a developer): %w", err)
+			}
+		} else {
+			return nil, fmt.Errorf("loading message receipts %w", err)
+		}
+	}
+	// so we only load the receipt array one
+	getReceipt := func(idx int) (*types.MessageReceipt, error) {
+		var r types.MessageReceipt
+		if found, err := rs.Get(uint64(idx), &r); err != nil {
+			return nil, err
+		} else if !found {
+			return nil, fmt.Errorf("failed to find receipt %d", idx)
+		}
+		return &r, nil
+	}
+
+	out := make([]*lens.BlockMessageReceipts, len(pts.Blocks()))
+	executionIndex := 0
+	// walk each block in tipset, `pts.Blocks()` has same ordering as `blkMsgs`.
+	for blkIdx := range pts.Blocks() {
+		// bls and secp messages for block
+		msgs := blkMsgs[blkIdx]
+		// index of messages in `out.Messages`
+		msgIdx := 0
+		// index or receipts in `out.Receipts`
+		receiptIdx := 0
+		out[blkIdx] = &lens.BlockMessageReceipts{
+			// block containing messages
+			Block: pts.Blocks()[blkIdx],
+			// total messages returned equal to sum of bls and secp messages
+			Message: make([]types.ChainMsg, len(msgs.BlsMessages)+len(msgs.SecpkMessages)),
+			// total receipts returned equal to sum of bls and secp messages
+			Receipt: make([]*types.MessageReceipt, len(msgs.BlsMessages)+len(msgs.SecpkMessages)),
+			// index of message indicating execution order.
+			MessageExecutionIndex: make(map[types.ChainMsg]int),
+		}
+		// walk bls messages and extract their receipts
+		for blsIdx := range msgs.BlsMessages {
+			receipt, err := getReceipt(executionIndex)
+			if err != nil {
+				return nil, err
+			}
+			out[blkIdx].Message[msgIdx] = msgs.BlsMessages[blsIdx]
+			out[blkIdx].Receipt[receiptIdx] = receipt
+			out[blkIdx].MessageExecutionIndex[msgs.BlsMessages[blsIdx]] = executionIndex
+			msgIdx++
+			receiptIdx++
+			executionIndex++
+		}
+		// walk secp messages and extract their receipts
+		for secpIdx := range msgs.SecpkMessages {
+			receipt, err := getReceipt(executionIndex)
+			if err != nil {
+				return nil, err
+			}
+			out[blkIdx].Message[msgIdx] = msgs.SecpkMessages[secpIdx]
+			out[blkIdx].Receipt[receiptIdx] = receipt
+			out[blkIdx].MessageExecutionIndex[msgs.SecpkMessages[secpIdx]] = executionIndex
+			msgIdx++
+			receiptIdx++
+			executionIndex++
+		}
+	}
+	return out, nil
+}
+
+func (v *vmWrapper) ShouldBurn(ctx context.Context, msg *types.Message, errcode exitcode.ExitCode) (bool, error) {
+	if lvmi, ok := v.vm.(*vm.LegacyVM); ok {
+		return lvmi.ShouldBurn(ctx, v.st, msg, errcode)
+	}
+
+	// Any "don't burn" rules from Network v13 onwards go here, for now we always return true
+	// source: https://github.com/filecoin-project/lotus/blob/v1.15.1/chain/vm/vm.go#L647
+	return true, nil
+}
+
+func (m *LilyNodeAPI) BurnFundsFn(ctx context.Context, ts *types.TipSet) (lens.ShouldBurnFn, error) {
+	// Create a skeleton vm just for calling ShouldBurn
+	// NB: VM is only required to process state prior to network v13
+	if util.DefaultNetwork.Version(ctx, ts.Height()) <= network2.Version12 {
+		vmi, err := vm.NewVM(ctx, &vm.VMOpts{
+			StateBase:      ts.ParentState(),
+			Epoch:          ts.Height(),
+			Bstore:         m.ChainAPI.Chain.StateBlockstore(),
+			Actors:         filcns.NewActorRegistry(),
+			Syscalls:       m.StateManager.Syscalls,
+			CircSupplyCalc: m.StateManager.GetVMCirculatingSupply,
+			NetworkVersion: util.DefaultNetwork.Version(ctx, ts.Height()),
+			BaseFee:        ts.Blocks()[0].ParentBaseFee,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("creating temporary vm: %w", err)
+		}
+		parentStateTree, err := state.LoadStateTree(m.ChainAPI.Chain.ActorStore(ctx), ts.ParentState())
+		if err != nil {
+			return nil, err
+		}
+		vmw := &vmWrapper{vm: vmi, st: parentStateTree}
+		return vmw.ShouldBurn, nil
+	}
+	// always burn after Network Version 12
+	return func(ctx context.Context, msg *types.Message, errcode exitcode.ExitCode) (bool, error) {
+		return true, nil
+	}, nil
+}
+
+func (m *LilyNodeAPI) CirculatingSupply(ctx context.Context, key types.TipSetKey) (api.CirculatingSupply, error) {
+	return m.StateAPI.StateVMCirculatingSupplyInternal(ctx, key)
+}
+
+func (m *LilyNodeAPI) ChainGetTipSetAfterHeight(ctx context.Context, epoch abi.ChainEpoch, key types.TipSetKey) (*types.TipSet, error) {
+	// TODO (Frrist): I copied this from lotus, I need it now to handle gap filling edge cases.
+	ts, err := m.ChainAPI.Chain.GetTipSetFromKey(ctx, key)
+	if err != nil {
+		return nil, fmt.Errorf("loading tipset %s: %w", key, err)
+	}
+	return m.ChainAPI.Chain.GetTipsetByHeight(ctx, epoch, ts, false)
 }
 
 func (m *LilyNodeAPI) Store() adt.Store {

--- a/lens/lily/struct.go
+++ b/lens/lily/struct.go
@@ -12,7 +12,6 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p-core/peer"
 
-	"github.com/filecoin-project/lily/lens"
 	"github.com/filecoin-project/lily/schedule"
 )
 
@@ -26,8 +25,7 @@ type LilyAPIStruct struct {
 	v0api.CommonStruct
 
 	Internal struct {
-		Store                                func() adt.Store                                                                  `perm:"read"`
-		GetExecutedAndBlockMessagesForTipset func(context.Context, *types.TipSet, *types.TipSet) (*lens.TipSetMessages, error) `perm:"read"`
+		Store func() adt.Store `perm:"read"`
 
 		LilyIndex  func(ctx context.Context, config *LilyIndexConfig) (interface{}, error)     `perm:"read"`
 		LilyWatch  func(context.Context, *LilyWatchConfig) (*schedule.JobSubmitResult, error)  `perm:"read"`
@@ -181,10 +179,6 @@ func (s *LilyAPIStruct) LilyGapFill(ctx context.Context, cfg *LilyGapFillConfig)
 
 func (s *LilyAPIStruct) Shutdown(ctx context.Context) error {
 	return s.Internal.Shutdown(ctx)
-}
-
-func (s *LilyAPIStruct) GetExecutedAndBlockMessagesForTipset(ctx context.Context, ts, pts *types.TipSet) (*lens.TipSetMessages, error) {
-	return s.Internal.GetExecutedAndBlockMessagesForTipset(ctx, ts, pts)
 }
 
 func (s *LilyAPIStruct) SyncState(ctx context.Context) (*api.SyncState, error) {

--- a/lens/util/repo.go
+++ b/lens/util/repo.go
@@ -220,24 +220,8 @@ func GetExecutedAndBlockMessagesForTipset(ctx context.Context, cs *store.ChainSt
 
 	}
 
-	blkMsgs := make([]*lens.BlockMessages, len(current.Blocks()))
-	for idx, blk := range current.Blocks() {
-		msgs, smsgs, err := cs.MessagesForBlock(ctx, blk)
-		if err != nil {
-			return nil, err
-		}
-		blkMsgs[idx] = &lens.BlockMessages{
-			Block:        blk,
-			BlsMessages:  msgs,
-			SecpMessages: smsgs,
-		}
-	}
-
-	span.AddEvent("read messages for current block")
-
 	return &lens.TipSetMessages{
 		Executed: emsgs,
-		Block:    blkMsgs,
 	}, nil
 }
 

--- a/tasks/actorstate/actorstate.go
+++ b/tasks/actorstate/actorstate.go
@@ -60,8 +60,6 @@ type ActorStateAPI interface {
 	// StateMinerSectors(ctx context.Context, addr address.Address, bf *bitfield.BitField, tsk types.TipSetKey) ([]*miner.SectorOnChainInfo, error)
 	Store() adt.Store
 
-	ExecutedAndBlockMessages(ctx context.Context, ts, pts *types.TipSet) (*lens.TipSetMessages, error)
-
 	TipSetMessageReceipts(ctx context.Context, ts, pts *types.TipSet) ([]*lens.BlockMessageReceipts, error)
 
 	DiffSectors(ctx context.Context, addr address.Address, ts, pts *types.TipSet, pre, cur miner.State) (*miner.SectorChanges, error)

--- a/tasks/actorstate/actorstate.go
+++ b/tasks/actorstate/actorstate.go
@@ -62,6 +62,8 @@ type ActorStateAPI interface {
 
 	ExecutedAndBlockMessages(ctx context.Context, ts, pts *types.TipSet) (*lens.TipSetMessages, error)
 
+	TipSetMessageReceipts(ctx context.Context, ts, pts *types.TipSet) ([]*tasks.BlockMessageReceipts, error)
+
 	DiffSectors(ctx context.Context, addr address.Address, ts, pts *types.TipSet, pre, cur miner.State) (*miner.SectorChanges, error)
 	DiffPreCommits(ctx context.Context, addr address.Address, ts, pts *types.TipSet, pre, cur miner.State) (*miner.PreCommitChanges, error)
 

--- a/tasks/actorstate/actorstate.go
+++ b/tasks/actorstate/actorstate.go
@@ -62,7 +62,7 @@ type ActorStateAPI interface {
 
 	ExecutedAndBlockMessages(ctx context.Context, ts, pts *types.TipSet) (*lens.TipSetMessages, error)
 
-	TipSetMessageReceipts(ctx context.Context, ts, pts *types.TipSet) ([]*tasks.BlockMessageReceipts, error)
+	TipSetMessageReceipts(ctx context.Context, ts, pts *types.TipSet) ([]*lens.BlockMessageReceipts, error)
 
 	DiffSectors(ctx context.Context, addr address.Address, ts, pts *types.TipSet, pre, cur miner.State) (*miner.SectorChanges, error)
 	DiffPreCommits(ctx context.Context, addr address.Address, ts, pts *types.TipSet, pre, cur miner.State) (*miner.PreCommitChanges, error)

--- a/tasks/actorstate/miner/post.go
+++ b/tasks/actorstate/miner/post.go
@@ -60,13 +60,13 @@ func (PoStExtractor) Extract(ctx context.Context, a actorstate.ActorInfo, node a
 		return pmap, nil
 	}
 
-	processPostMsg := func(msg *types.Message, rec *types.MessageReceipt) error {
+	processPostMsg := func(msg types.ChainMsg, rec *types.MessageReceipt) error {
 		sectors := make([]uint64, 0)
 		if rec == nil || rec.ExitCode.IsError() {
 			return nil
 		}
 		params := minertypes.SubmitWindowedPoStParams{}
-		if err := params.UnmarshalCBOR(bytes.NewBuffer(msg.Params)); err != nil {
+		if err := params.UnmarshalCBOR(bytes.NewBuffer(msg.VMMessage().Params)); err != nil {
 			return fmt.Errorf("unmarshal post params: %w", err)
 		}
 
@@ -119,8 +119,8 @@ func (PoStExtractor) Extract(ctx context.Context, a actorstate.ActorInfo, node a
 			return nil, err
 		}
 		for itr.HasNext() {
-			msg, rec := itr.Next()
-			if msg.To == a.Address && msg.Method == 5 /* miner.SubmitWindowedPoSt */ {
+			msg, _, rec := itr.Next()
+			if msg.VMMessage().To == a.Address && msg.VMMessage().Method == 5 /* miner.SubmitWindowedPoSt */ {
 				if err := processPostMsg(msg, rec); err != nil {
 					return nil, fmt.Errorf("process post msg: %w", err)
 				}

--- a/tasks/api.go
+++ b/tasks/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/chain/types"
 
@@ -51,10 +52,9 @@ type DataSource interface {
 	MinerPower(ctx context.Context, addr address.Address, ts *types.TipSet) (*api.MinerPower, error)
 	ActorStateChanges(ctx context.Context, ts, pts *types.TipSet) (ActorStateChangeDiff, error)
 	MessageExecutions(ctx context.Context, ts, pts *types.TipSet) ([]*lens.MessageExecution, error)
-	ExecutedAndBlockMessages(ctx context.Context, ts, pts *types.TipSet) (*lens.TipSetMessages, error)
 	Store() adt.Store
 
-	TipSetMessages(ctx context.Context, ts *types.TipSet) ([]types.ChainMsg, error)
+	ComputeBaseFee(ctx context.Context, ts *types.TipSet) (abi.TokenAmount, error)
 	TipSetBlockMessages(ctx context.Context, ts *types.TipSet) ([]*lens.BlockMessages, error)
 
 	TipSetMessageReceipts(ctx context.Context, ts, pts *types.TipSet) ([]*lens.BlockMessageReceipts, error)
@@ -64,5 +64,5 @@ type DataSource interface {
 
 	MinerLoad(store adt.Store, act *types.Actor) (miner.State, error)
 
-	ShouldBrunFn(ctx context.Context, ts, pts *types.TipSet) (lens.ShouldBurnFn, error)
+	ShouldBrunFn(ctx context.Context, ts *types.TipSet) (lens.ShouldBurnFn, error)
 }

--- a/tasks/api.go
+++ b/tasks/api.go
@@ -64,5 +64,5 @@ type DataSource interface {
 
 	MinerLoad(store adt.Store, act *types.Actor) (miner.State, error)
 
-	ShouldBrunFn(ctx context.Context, ts *types.TipSet) (lens.ShouldBurnFn, error)
+	ShouldBurnFn(ctx context.Context, ts *types.TipSet) (lens.ShouldBurnFn, error)
 }

--- a/tasks/api.go
+++ b/tasks/api.go
@@ -43,6 +43,13 @@ type ActorStateChange struct {
 
 type ActorStateChangeDiff map[address.Address]ActorStateChange
 
+type BlockMessageReceipts struct {
+	Block   *types.BlockHeader
+	Message *types.Message
+	Receipt *types.MessageReceipt
+	Index   int
+}
+
 type DataSource interface {
 	TipSet(ctx context.Context, tsk types.TipSetKey) (*types.TipSet, error)
 	Actor(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*types.Actor, error)
@@ -56,6 +63,8 @@ type DataSource interface {
 
 	TipSetMessages(ctx context.Context, ts *types.TipSet) ([]types.ChainMsg, error)
 	TipSetBlockMessages(ctx context.Context, ts *types.TipSet) ([]*lens.BlockMessages, error)
+
+	TipSetMessageReceipts(ctx context.Context, ts, pts *types.TipSet) ([]*BlockMessageReceipts, error)
 
 	DiffSectors(ctx context.Context, addr address.Address, ts, pts *types.TipSet, pre, cur miner.State) (*miner.SectorChanges, error)
 	DiffPreCommits(ctx context.Context, addr address.Address, ts, pts *types.TipSet, pre, cur miner.State) (*miner.PreCommitChanges, error)

--- a/tasks/api.go
+++ b/tasks/api.go
@@ -84,6 +84,10 @@ func (mri *MessageReceiptIterator) Next() (*types.Message, *types.MessageReceipt
 	return nil, nil
 }
 
+func (mri *MessageReceiptIterator) Reset() {
+	mri.idx = 0
+}
+
 func (mri *MessageReceiptIterator) Index() int {
 	return mri.idx
 }

--- a/tasks/api.go
+++ b/tasks/api.go
@@ -2,7 +2,6 @@ package tasks
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/lotus/api"
@@ -44,54 +43,6 @@ type ActorStateChange struct {
 
 type ActorStateChangeDiff map[address.Address]ActorStateChange
 
-type BlockMessageReceipts struct {
-	Block   *types.BlockHeader
-	Message []*types.Message
-	Receipt []*types.MessageReceipt
-}
-
-func (bmr *BlockMessageReceipts) Iterator() (*MessageReceiptIterator, error) {
-	if len(bmr.Message) != len(bmr.Receipt) {
-		return nil, fmt.Errorf("invalid construction, expected equal number receipts (%d) and messages (%d)", len(bmr.Receipt), len(bmr.Message))
-	}
-	return &MessageReceiptIterator{
-		idx:      0,
-		msgs:     bmr.Message,
-		receipts: bmr.Receipt,
-	}, nil
-}
-
-type MessageReceiptIterator struct {
-	idx      int
-	msgs     []*types.Message
-	receipts []*types.MessageReceipt
-}
-
-func (mri *MessageReceiptIterator) HasNext() bool {
-	if mri.idx < len(mri.msgs) {
-		return true
-	}
-	return false
-}
-
-func (mri *MessageReceiptIterator) Next() (*types.Message, *types.MessageReceipt) {
-	if mri.HasNext() {
-		msg := mri.msgs[mri.idx]
-		rec := mri.receipts[mri.idx]
-		mri.idx++
-		return msg, rec
-	}
-	return nil, nil
-}
-
-func (mri *MessageReceiptIterator) Reset() {
-	mri.idx = 0
-}
-
-func (mri *MessageReceiptIterator) Index() int {
-	return mri.idx
-}
-
 type DataSource interface {
 	TipSet(ctx context.Context, tsk types.TipSetKey) (*types.TipSet, error)
 	Actor(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*types.Actor, error)
@@ -106,7 +57,7 @@ type DataSource interface {
 	TipSetMessages(ctx context.Context, ts *types.TipSet) ([]types.ChainMsg, error)
 	TipSetBlockMessages(ctx context.Context, ts *types.TipSet) ([]*lens.BlockMessages, error)
 
-	TipSetMessageReceipts(ctx context.Context, ts, pts *types.TipSet) ([]*BlockMessageReceipts, error)
+	TipSetMessageReceipts(ctx context.Context, ts, pts *types.TipSet) ([]*lens.BlockMessageReceipts, error)
 
 	DiffSectors(ctx context.Context, addr address.Address, ts, pts *types.TipSet, pre, cur miner.State) (*miner.SectorChanges, error)
 	DiffPreCommits(ctx context.Context, addr address.Address, ts, pts *types.TipSet, pre, cur miner.State) (*miner.PreCommitChanges, error)

--- a/tasks/api.go
+++ b/tasks/api.go
@@ -54,6 +54,9 @@ type DataSource interface {
 	ExecutedAndBlockMessages(ctx context.Context, ts, pts *types.TipSet) (*lens.TipSetMessages, error)
 	Store() adt.Store
 
+	TipSetMessages(ctx context.Context, ts *types.TipSet) ([]types.ChainMsg, error)
+	TipSetBlockMessages(ctx context.Context, ts *types.TipSet) ([]*lens.BlockMessages, error)
+
 	DiffSectors(ctx context.Context, addr address.Address, ts, pts *types.TipSet, pre, cur miner.State) (*miner.SectorChanges, error)
 	DiffPreCommits(ctx context.Context, addr address.Address, ts, pts *types.TipSet, pre, cur miner.State) (*miner.PreCommitChanges, error)
 

--- a/tasks/api.go
+++ b/tasks/api.go
@@ -63,4 +63,6 @@ type DataSource interface {
 	DiffPreCommits(ctx context.Context, addr address.Address, ts, pts *types.TipSet, pre, cur miner.State) (*miner.PreCommitChanges, error)
 
 	MinerLoad(store adt.Store, act *types.Actor) (miner.State, error)
+
+	ShouldBrunFn(ctx context.Context, ts, pts *types.TipSet) (lens.ShouldBurnFn, error)
 }

--- a/tasks/messages/gasoutput/task.go
+++ b/tasks/messages/gasoutput/task.go
@@ -4,12 +4,17 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/ipfs/go-cid"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/filecoin-project/lily/chain/actors/builtin"
+	"github.com/filecoin-project/lily/chain/datasource"
+	"github.com/filecoin-project/lily/lens"
+	"github.com/filecoin-project/lily/lens/util"
 	"github.com/filecoin-project/lily/model"
 	derivedmodel "github.com/filecoin-project/lily/model/derived"
 	visormodel "github.com/filecoin-project/lily/model/visor"
@@ -45,20 +50,49 @@ func (t *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 		StateRoot: current.ParentState().String(),
 	}
 
-	tsMsgs, err := t.node.ExecutedAndBlockMessages(ctx, current, executed)
-	if err != nil {
-		report.ErrorsDetected = fmt.Errorf("getting executed and block messages: %w", err)
+	grp, ctx := errgroup.WithContext(ctx)
+
+	var getActorCodeFn func(address address.Address) (cid.Cid, bool)
+	grp.Go(func() error {
+		var err error
+		getActorCodeFn, err = util.MakeGetActorCodeFunc(ctx, t.node.Store(), current, executed)
+		if err != nil {
+			return fmt.Errorf("getting actor code lookup function: %w", err)
+		}
+		return nil
+	})
+
+	var blkMsgRec []*lens.BlockMessageReceipts
+	grp.Go(func() error {
+		var err error
+		blkMsgRec, err = t.node.TipSetMessageReceipts(ctx, current, executed)
+		if err != nil {
+			return fmt.Errorf("getting messages and receipts: %w", err)
+		}
+		return nil
+	})
+	var burnFn lens.ShouldBurnFn
+	grp.Go(func() error {
+		var err error
+		burnFn, err = t.node.ShouldBrunFn(ctx, current, executed)
+		if err != nil {
+			return fmt.Errorf("getting should burn function: %w", err)
+		}
+		return nil
+	})
+
+	if err := grp.Wait(); err != nil {
+		report.ErrorsDetected = err
 		return nil, report, nil
 	}
-	emsgs := tsMsgs.Executed
 
 	var (
-		gasOutputsResults = make(derivedmodel.GasOutputsList, 0, len(emsgs))
-		errorsDetected    = make([]*messages.MessageError, 0, len(emsgs))
-		exeMsgSeen        = make(map[cid.Cid]bool, len(emsgs))
+		gasOutputsResults = make(derivedmodel.GasOutputsList, 0)
+		errorsDetected    = make([]*messages.MessageError, 0)
+		exeMsgSeen        = make(map[cid.Cid]bool)
 	)
 
-	for _, m := range emsgs {
+	for _, msgrec := range blkMsgRec {
 		// Stop processing if we have been told to cancel
 		select {
 		case <-ctx.Done():
@@ -66,49 +100,66 @@ func (t *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 		default:
 		}
 
-		if exeMsgSeen[m.Cid] {
-			continue
-		}
-		exeMsgSeen[m.Cid] = true
-
-		var msgSize int
-		if b, err := m.Message.Serialize(); err == nil {
-			msgSize = len(b)
-		} else {
-			errorsDetected = append(errorsDetected, &messages.MessageError{
-				Cid:   m.Cid,
-				Error: fmt.Errorf("failed to serialize message: %w", err).Error(),
-			})
+		itr, err := msgrec.Iterator()
+		if err != nil {
+			return nil, nil, err
 		}
 
-		actorName := builtin.ActorNameByCode(m.ToActorCode)
-		gasOutput := &derivedmodel.GasOutputs{
-			Height:             int64(m.Height),
-			Cid:                m.Cid.String(),
-			From:               m.Message.From.String(),
-			To:                 m.Message.To.String(),
-			Value:              m.Message.Value.String(),
-			GasFeeCap:          m.Message.GasFeeCap.String(),
-			GasPremium:         m.Message.GasPremium.String(),
-			GasLimit:           m.Message.GasLimit,
-			Nonce:              m.Message.Nonce,
-			Method:             uint64(m.Message.Method),
-			StateRoot:          m.BlockHeader.ParentStateRoot.String(),
-			ExitCode:           int64(m.Receipt.ExitCode),
-			GasUsed:            m.Receipt.GasUsed,
-			ParentBaseFee:      m.BlockHeader.ParentBaseFee.String(),
-			SizeBytes:          msgSize,
-			BaseFeeBurn:        m.GasOutputs.BaseFeeBurn.String(),
-			OverEstimationBurn: m.GasOutputs.OverEstimationBurn.String(),
-			MinerPenalty:       m.GasOutputs.MinerPenalty.String(),
-			MinerTip:           m.GasOutputs.MinerTip.String(),
-			Refund:             m.GasOutputs.Refund.String(),
-			GasRefund:          m.GasOutputs.GasRefund,
-			GasBurned:          m.GasOutputs.GasBurned,
-			ActorName:          actorName,
-			ActorFamily:        builtin.ActorFamily(actorName),
+		blk := msgrec.Block
+		for itr.HasNext() {
+			m, r := itr.Next()
+			if exeMsgSeen[m.Cid()] {
+				continue
+			}
+			exeMsgSeen[m.Cid()] = true
+
+			var msgSize int
+			if b, err := m.Serialize(); err == nil {
+				msgSize = len(b)
+			} else {
+				errorsDetected = append(errorsDetected, &messages.MessageError{
+					Cid:   m.Cid(),
+					Error: fmt.Errorf("failed to serialize message: %w", err).Error(),
+				})
+			}
+
+			toActorCode, found := getActorCodeFn(m.To)
+			if !found {
+				toActorCode = cid.Undef
+			}
+			gasOutputs, err := datasource.ComputeGasOutputs(ctx, blk, m, r, burnFn)
+			if err != nil {
+				return nil, nil, err
+			}
+			actorName := builtin.ActorNameByCode(toActorCode)
+			gasOutput := &derivedmodel.GasOutputs{
+				Height:             int64(blk.Height),
+				Cid:                m.Cid().String(),
+				From:               m.From.String(),
+				To:                 m.To.String(),
+				Value:              m.Value.String(),
+				GasFeeCap:          m.GasFeeCap.String(),
+				GasPremium:         m.GasPremium.String(),
+				GasLimit:           m.GasLimit,
+				Nonce:              m.Nonce,
+				Method:             uint64(m.Method),
+				StateRoot:          blk.ParentStateRoot.String(),
+				ExitCode:           int64(r.ExitCode),
+				GasUsed:            r.GasUsed,
+				ParentBaseFee:      blk.ParentBaseFee.String(),
+				SizeBytes:          msgSize,
+				BaseFeeBurn:        gasOutputs.BaseFeeBurn.String(),
+				OverEstimationBurn: gasOutputs.OverEstimationBurn.String(),
+				MinerPenalty:       gasOutputs.MinerPenalty.String(),
+				MinerTip:           gasOutputs.MinerTip.String(),
+				Refund:             gasOutputs.Refund.String(),
+				GasRefund:          gasOutputs.GasRefund,
+				GasBurned:          gasOutputs.GasBurned,
+				ActorName:          actorName,
+				ActorFamily:        builtin.ActorFamily(actorName),
+			}
+			gasOutputsResults = append(gasOutputsResults, gasOutput)
 		}
-		gasOutputsResults = append(gasOutputsResults, gasOutput)
 	}
 
 	if len(errorsDetected) > 0 {

--- a/tasks/messages/gasoutput/task.go
+++ b/tasks/messages/gasoutput/task.go
@@ -74,7 +74,7 @@ func (t *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 	var burnFn lens.ShouldBurnFn
 	grp.Go(func() error {
 		var err error
-		burnFn, err = t.node.ShouldBrunFn(grpCtx, executed)
+		burnFn, err = t.node.ShouldBurnFn(grpCtx, executed)
 		if err != nil {
 			return fmt.Errorf("getting should burn function: %w", err)
 		}

--- a/tasks/messages/parsedmessage/task.go
+++ b/tasks/messages/parsedmessage/task.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/filecoin-project/lily/lens"
 	"github.com/filecoin-project/lily/lens/util"
 	"github.com/filecoin-project/lily/model"
 	messagemodel "github.com/filecoin-project/lily/model/messages"
@@ -63,7 +64,7 @@ func (t *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 		return nil
 	})
 
-	var blkMsgRec []*tasks.BlockMessageReceipts
+	var blkMsgRec []*lens.BlockMessageReceipts
 	grp.Go(func() error {
 		var err error
 		blkMsgRec, err = t.node.TipSetMessageReceipts(ctx, current, executed)

--- a/tasks/messages/parsedmessage/task.go
+++ b/tasks/messages/parsedmessage/task.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/filecoin-project/lily/lens/util"
 	"github.com/filecoin-project/lily/model"
@@ -49,22 +51,42 @@ func (t *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 		StateRoot: current.ParentState().String(),
 	}
 
-	tsMsgs, err := t.node.ExecutedAndBlockMessages(ctx, current, executed)
-	if err != nil {
-		report.ErrorsDetected = fmt.Errorf("getting executed and block messages: %w", err)
+	grp, ctx := errgroup.WithContext(ctx)
+
+	var getActorCodeFn func(address address.Address) (cid.Cid, bool)
+	grp.Go(func() error {
+		var err error
+		getActorCodeFn, err = util.MakeGetActorCodeFunc(ctx, t.node.Store(), current, executed)
+		if err != nil {
+			return fmt.Errorf("getting actor code lookup function: %w", err)
+		}
+		return nil
+	})
+
+	var blkMsgRec []*tasks.BlockMessageReceipts
+	grp.Go(func() error {
+		var err error
+		blkMsgRec, err = t.node.TipSetMessageReceipts(ctx, current, executed)
+		if err != nil {
+			return fmt.Errorf("getting messages and receipts: %w", err)
+		}
+		return nil
+	})
+
+	if err := grp.Wait(); err != nil {
+		report.ErrorsDetected = err
 		return nil, report, nil
 	}
-	emsgs := tsMsgs.Executed
 
 	var (
-		parsedMessageResults = make(messagemodel.ParsedMessages, 0, len(emsgs))
-		errorsDetected       = make([]*messages.MessageError, 0, len(emsgs))
-		exeMsgSeen           = make(map[cid.Cid]bool, len(emsgs))
+		parsedMessageResults = make(messagemodel.ParsedMessages, 0)
+		errorsDetected       = make([]*messages.MessageError, 0)
+		exeMsgSeen           = make(map[cid.Cid]bool)
 		totalGasLimit        int64
 		totalUniqGasLimit    int64
 	)
 
-	for _, m := range emsgs {
+	for _, msgrec := range blkMsgRec {
 		// Stop processing if we have been told to cancel
 		select {
 		case <-ctx.Done():
@@ -72,57 +94,69 @@ func (t *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 		default:
 		}
 
+		itr, err := msgrec.Iterator()
+		if err != nil {
+			return nil, nil, err
+		}
+
 		// calculate total gas limit of executed messages regardless of duplicates.
-		for range m.Blocks {
-			totalGasLimit += m.Message.GasLimit
+		for itr.HasNext() {
+			msg, _ := itr.Next()
+			totalGasLimit += msg.GasLimit
 		}
 
-		if exeMsgSeen[m.Cid] {
-			continue
-		}
-		exeMsgSeen[m.Cid] = true
-		totalUniqGasLimit += m.Message.GasLimit
+		// reset the iterator to beginning
+		itr.Reset()
 
-		if m.ToActorCode.Defined() {
-			method, params, err := util.MethodAndParamsForMessage(m.Message, m.ToActorCode)
-			if err == nil {
-				pm := &messagemodel.ParsedMessage{
-					Height: int64(m.Height),
-					Cid:    m.Cid.String(),
-					From:   m.Message.From.String(),
-					To:     m.Message.To.String(),
-					Value:  m.Message.Value.String(),
-					Method: method,
-					Params: params,
-				}
-				parsedMessageResults = append(parsedMessageResults, pm)
-			} else {
-				if m.Receipt.ExitCode == exitcode.ErrSerialization ||
-					m.Receipt.ExitCode == exitcode.ErrIllegalArgument ||
-					m.Receipt.ExitCode == exitcode.SysErrInvalidMethod ||
-					// UsrErrUnsupportedMethod TODO: https://github.com/filecoin-project/go-state-types/pull/44
-					m.Receipt.ExitCode == exitcode.ExitCode(22) {
-					// ignore the parse error since the params are probably malformed, as reported by the vm
-				} else {
-					log.Errorw("parsing message", "error", err, "cid", m.Message.Cid().String(), "receipt", m.Receipt)
-					errorsDetected = append(errorsDetected, &messages.MessageError{
-						Cid:   m.Cid,
-						Error: fmt.Errorf("failed to parse message params: %w", err).Error(),
-					})
-				}
+		for itr.HasNext() {
+			m, r := itr.Next()
+			if exeMsgSeen[m.Cid()] {
+				continue
 			}
-		} else {
-			// No destination actor code. Normally Lotus will create an account actor for unknown addresses but if the
-			// message fails then Lotus will not allow the actor to be created and we are left with an address of an
-			// unknown type.
-			// If the message was executed it means we are out of step with Lotus behaviour somehow. This probably
-			// indicates that Lily actor type detection is out of date.
-			if m.Receipt.ExitCode == 0 {
-				log.Errorw("parsing message", "error", err, "cid", m.Message.Cid().String(), "receipt", m.Receipt)
+			exeMsgSeen[m.Cid()] = true
+			totalUniqGasLimit += m.GasLimit
+
+			toActorCode, found := getActorCodeFn(m.To)
+			if !found && r.ExitCode == 0 {
+				// No destination actor code. Normally Lotus will create an account actor for unknown addresses but if the
+				// message fails then Lotus will not allow the actor to be created and we are left with an address of an
+				// unknown type.
+				// If the message was executed it means we are out of step with Lotus behaviour somehow. This probably
+				// indicates that Lily actor type detection is out of date.
+				log.Errorw("parsing message", "error", err, "cid", m.Cid().String(), "receipt", r)
 				errorsDetected = append(errorsDetected, &messages.MessageError{
-					Cid:   m.Cid,
+					Cid:   m.Cid(),
 					Error: fmt.Errorf("failed to parse message params: missing to actor code").Error(),
 				})
+			} else {
+				method, params, err := util.MethodAndParamsForMessage(m, toActorCode)
+				if err == nil {
+					pm := &messagemodel.ParsedMessage{
+						Height: int64(msgrec.Block.Height),
+						Cid:    m.Cid().String(),
+						From:   m.From.String(),
+						To:     m.To.String(),
+						Value:  m.Value.String(),
+						Method: method,
+						Params: params,
+					}
+					parsedMessageResults = append(parsedMessageResults, pm)
+				} else {
+					if r.ExitCode == exitcode.ErrSerialization ||
+						r.ExitCode == exitcode.ErrIllegalArgument ||
+						r.ExitCode == exitcode.SysErrInvalidMethod ||
+						// UsrErrUnsupportedMethod TODO: https://github.com/filecoin-project/go-state-types/pull/44
+						r.ExitCode == exitcode.ExitCode(22) {
+						// ignore the parse error since the params are probably malformed, as reported by the vm
+
+					} else {
+						log.Errorw("parsing message", "error", err, "cid", m.Cid().String(), "receipt", r)
+						errorsDetected = append(errorsDetected, &messages.MessageError{
+							Cid:   m.Cid(),
+							Error: fmt.Errorf("failed to parse message params: %w", err).Error(),
+						})
+					}
+				}
 			}
 		}
 	}

--- a/tasks/messages/receipt/task.go
+++ b/tasks/messages/receipt/task.go
@@ -69,19 +69,22 @@ func (t *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 		}
 
 		for itr.HasNext() {
-			msg, rec := itr.Next()
+			msg, index, rec := itr.Next()
 			if msgsSeen[msg.Cid()] {
 				continue
 			}
 			msgsSeen[msg.Cid()] = true
 
 			rcpt := &messagemodel.Receipt{
+				// use current's height and stateroot since receipts returned from TipSetMessageReceipts come from current
+				// the messages from `executed` are applied (executed) to produce the stateroot and receipts in `current`.
 				Height:    int64(current.Height()),
-				Message:   msg.Cid().String(),
 				StateRoot: current.ParentState().String(),
-				Idx:       itr.Index(),
-				ExitCode:  int64(rec.ExitCode),
-				GasUsed:   rec.GasUsed,
+
+				Message:  msg.Cid().String(),
+				Idx:      index,
+				ExitCode: int64(rec.ExitCode),
+				GasUsed:  rec.GasUsed,
 			}
 			receiptResults = append(receiptResults, rcpt)
 		}

--- a/tasks/msapprovals/msapprovals.go
+++ b/tasks/msapprovals/msapprovals.go
@@ -6,12 +6,16 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/lotus/chain/actors/builtin"
 	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/ipfs/go-cid"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/filecoin-project/lily/chain/actors/builtin/multisig"
+	"github.com/filecoin-project/lily/lens/util"
 	"github.com/filecoin-project/lily/tasks"
 
 	"github.com/filecoin-project/lily/model"
@@ -52,17 +56,37 @@ func (p *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 		StateRoot: current.ParentState().String(),
 	}
 
-	tsMsgs, err := p.node.ExecutedAndBlockMessages(ctx, current, executed)
-	if err != nil {
-		report.ErrorsDetected = fmt.Errorf("getting executed and block messages: %w", err)
+	grp, ctx := errgroup.WithContext(ctx)
+
+	var getActorCodeFn func(address address.Address) (cid.Cid, bool)
+	grp.Go(func() error {
+		var err error
+		getActorCodeFn, err = util.MakeGetActorCodeFunc(ctx, p.node.Store(), current, executed)
+		if err != nil {
+			return fmt.Errorf("getting actor code lookup function: %w", err)
+		}
+		return nil
+	})
+
+	var blkMsgRec []*tasks.BlockMessageReceipts
+	grp.Go(func() error {
+		var err error
+		blkMsgRec, err = p.node.TipSetMessageReceipts(ctx, current, executed)
+		if err != nil {
+			return fmt.Errorf("getting messages and receipts: %w", err)
+		}
+		return nil
+	})
+
+	if err := grp.Wait(); err != nil {
+		report.ErrorsDetected = err
 		return nil, report, nil
 	}
-	emsgs := tsMsgs.Executed
 
-	errorsDetected := make([]*MultisigError, 0, len(emsgs))
+	errorsDetected := make([]*MultisigError, 0)
 	results := make(msapprovals.MultisigApprovalList, 0) // no initial size capacity since approvals are rare
 
-	for _, m := range emsgs {
+	for _, msgrec := range blkMsgRec {
 		// Stop processing if we have been told to cancel
 		select {
 		case <-ctx.Done():
@@ -70,100 +94,112 @@ func (p *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 		default:
 		}
 
-		// Only interested in messages to multisig actors
-		if !builtin.IsMultisigActor(m.ToActorCode) {
-			continue
-		}
-
-		// Only interested in successful messages
-		if !m.Receipt.ExitCode.IsSuccess() {
-			continue
-		}
-
-		// Only interested in propose and approve messages
-		if m.Message.Method != ProposeMethodNum && m.Message.Method != ApproveMethodNum {
-			continue
-		}
-
-		applied, tx, err := p.getTransactionIfApplied(ctx, m.Message, m.Receipt, current)
+		itr, err := msgrec.Iterator()
 		if err != nil {
-			errorsDetected = append(errorsDetected, &MultisigError{
-				Addr:  m.Message.To.String(),
-				Error: fmt.Errorf("failed to find transaction: %w", err).Error(),
-			})
-			continue
+			return nil, nil, err
 		}
 
-		// Only interested in messages that applied a transaction
-		if !applied {
-			continue
-		}
+		for itr.HasNext() {
+			msg, rec := itr.Next()
+			// Only interested in successful messages
+			if !rec.ExitCode.IsSuccess() {
+				continue
+			}
 
-		appr := msapprovals.MultisigApproval{
-			Height:        int64(executed.Height()),
-			StateRoot:     executed.ParentState().String(),
-			MultisigID:    m.Message.To.String(),
-			Message:       m.Cid.String(),
-			Method:        uint64(m.Message.Method),
-			Approver:      m.Message.From.String(),
-			GasUsed:       m.Receipt.GasUsed,
-			TransactionID: tx.id,
-			To:            tx.to,
-			Value:         tx.value,
-		}
+			// Only interested in messages to multisig actors
+			msgToCode, found := getActorCodeFn(msg.To)
+			if !found {
+				return nil, nil, fmt.Errorf("failed to find to actor %s height %d message %s", msg.To, current.Height(), msg.Cid())
+			}
+			if !builtin.IsMultisigActor(msgToCode) {
+				continue
+			}
 
-		// Get state of actor after the message has been applied
-		act, err := p.node.Actor(ctx, m.Message.To, current.Key())
-		if err != nil {
-			errorsDetected = append(errorsDetected, &MultisigError{
-				Addr:  m.Message.To.String(),
-				Error: fmt.Errorf("failed to load actor: %w", err).Error(),
-			})
-			continue
-		}
+			// Only interested in propose and approve messages
+			if msg.Method != ProposeMethodNum && msg.Method != ApproveMethodNum {
+				continue
+			}
 
-		actorState, err := multisig.Load(p.node.Store(), act)
-		if err != nil {
-			errorsDetected = append(errorsDetected, &MultisigError{
-				Addr:  m.Message.To.String(),
-				Error: fmt.Errorf("failed to load actor state: %w", err).Error(),
-			})
-			continue
-		}
+			applied, tx, err := p.getTransactionIfApplied(ctx, msg, rec, current)
+			if err != nil {
+				errorsDetected = append(errorsDetected, &MultisigError{
+					Addr:  msg.To.String(),
+					Error: fmt.Errorf("failed to find transaction: %w", err).Error(),
+				})
+				continue
+			}
 
-		ib, err := actorState.InitialBalance()
-		if err != nil {
-			errorsDetected = append(errorsDetected, &MultisigError{
-				Addr:  m.Message.To.String(),
-				Error: fmt.Errorf("failed to read initial balance: %w", err).Error(),
-			})
-			continue
-		}
-		appr.InitialBalance = ib.String()
+			// Only interested in messages that applied a transaction
+			if !applied {
+				continue
+			}
 
-		threshold, err := actorState.Threshold()
-		if err != nil {
-			errorsDetected = append(errorsDetected, &MultisigError{
-				Addr:  m.Message.To.String(),
-				Error: fmt.Errorf("failed to read initial balance: %w", err).Error(),
-			})
-			continue
-		}
-		appr.Threshold = threshold
+			appr := msapprovals.MultisigApproval{
+				Height:        int64(executed.Height()),
+				StateRoot:     executed.ParentState().String(),
+				MultisigID:    msg.To.String(),
+				Message:       msg.Cid().String(),
+				Method:        uint64(msg.Method),
+				Approver:      msg.From.String(),
+				GasUsed:       rec.GasUsed,
+				TransactionID: tx.id,
+				To:            tx.to,
+				Value:         tx.value,
+			}
 
-		signers, err := actorState.Signers()
-		if err != nil {
-			errorsDetected = append(errorsDetected, &MultisigError{
-				Addr:  m.Message.To.String(),
-				Error: fmt.Errorf("failed to read signers: %w", err).Error(),
-			})
-			continue
-		}
-		for _, addr := range signers {
-			appr.Signers = append(appr.Signers, addr.String())
-		}
+			// Get state of actor after the message has been applied
+			act, err := p.node.Actor(ctx, msg.To, current.Key())
+			if err != nil {
+				errorsDetected = append(errorsDetected, &MultisigError{
+					Addr:  msg.To.String(),
+					Error: fmt.Errorf("failed to load actor: %w", err).Error(),
+				})
+				continue
+			}
 
-		results = append(results, &appr)
+			actorState, err := multisig.Load(p.node.Store(), act)
+			if err != nil {
+				errorsDetected = append(errorsDetected, &MultisigError{
+					Addr:  msg.To.String(),
+					Error: fmt.Errorf("failed to load actor state: %w", err).Error(),
+				})
+				continue
+			}
+
+			ib, err := actorState.InitialBalance()
+			if err != nil {
+				errorsDetected = append(errorsDetected, &MultisigError{
+					Addr:  msg.To.String(),
+					Error: fmt.Errorf("failed to read initial balance: %w", err).Error(),
+				})
+				continue
+			}
+			appr.InitialBalance = ib.String()
+
+			threshold, err := actorState.Threshold()
+			if err != nil {
+				errorsDetected = append(errorsDetected, &MultisigError{
+					Addr:  msg.To.String(),
+					Error: fmt.Errorf("failed to read initial balance: %w", err).Error(),
+				})
+				continue
+			}
+			appr.Threshold = threshold
+
+			signers, err := actorState.Signers()
+			if err != nil {
+				errorsDetected = append(errorsDetected, &MultisigError{
+					Addr:  msg.To.String(),
+					Error: fmt.Errorf("failed to read signers: %w", err).Error(),
+				})
+				continue
+			}
+			for _, addr := range signers {
+				appr.Signers = append(appr.Signers, addr.String())
+			}
+
+			results = append(results, &appr)
+		}
 	}
 
 	if len(errorsDetected) != 0 {

--- a/tasks/msapprovals/msapprovals.go
+++ b/tasks/msapprovals/msapprovals.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/filecoin-project/lily/chain/actors/builtin/multisig"
+	"github.com/filecoin-project/lily/lens"
 	"github.com/filecoin-project/lily/lens/util"
 	"github.com/filecoin-project/lily/tasks"
 
@@ -68,7 +69,7 @@ func (p *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 		return nil
 	})
 
-	var blkMsgRec []*tasks.BlockMessageReceipts
+	var blkMsgRec []*lens.BlockMessageReceipts
 	grp.Go(func() error {
 		var err error
 		blkMsgRec, err = p.node.TipSetMessageReceipts(ctx, current, executed)

--- a/tasks/test/api.go
+++ b/tasks/test/api.go
@@ -17,6 +17,13 @@ type MockActorStateAPI struct {
 	mock.Mock
 }
 
+func (m *MockActorStateAPI) TipSetMessageReceipts(ctx context.Context, ts, pts *types.TipSet) ([]*lens.BlockMessageReceipts, error) {
+	args := m.Called(ctx, ts, pts)
+	tsmsgs := args.Get(0)
+	err := args.Error(1)
+	return tsmsgs.([]*lens.BlockMessageReceipts), err
+}
+
 func (m *MockActorStateAPI) MinerLoad(store adt.Store, act *types.Actor) (miner.State, error) {
 	args := m.Called(store, act)
 	state := args.Get(0)
@@ -54,13 +61,6 @@ func (m *MockActorStateAPI) ActorState(ctx context.Context, addr address.Address
 func (m *MockActorStateAPI) Store() adt.Store {
 	m.Called()
 	return nil
-}
-
-func (m *MockActorStateAPI) ExecutedAndBlockMessages(ctx context.Context, ts, pts *types.TipSet) (*lens.TipSetMessages, error) {
-	args := m.Called(ctx, ts, pts)
-	tsmsgs := args.Get(0)
-	err := args.Error(1)
-	return tsmsgs.(*lens.TipSetMessages), err
 }
 
 func (m *MockActorStateAPI) DiffPreCommits(ctx context.Context, addr address.Address, ts, pts *types.TipSet, pre, cur miner.State) (*miner.PreCommitChanges, error) {

--- a/testutil/lens.go
+++ b/testutil/lens.go
@@ -25,6 +25,31 @@ type APIWrapper struct {
 	ctx context.Context
 }
 
+func (aw *APIWrapper) BurnFundsFn(ctx context.Context, ts *types.TipSet) (lens.ShouldBurnFn, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (aw *APIWrapper) GetMessageExecutionsForTipSet(ctx context.Context, ts, pts *types.TipSet) ([]*lens.MessageExecution, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (aw *APIWrapper) ComputeBaseFee(ctx context.Context, ts *types.TipSet) (abi.TokenAmount, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (aw *APIWrapper) MessagesForTipSetBlocks(ctx context.Context, ts *types.TipSet) ([]*lens.BlockMessages, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (aw *APIWrapper) TipSetMessageReceipts(ctx context.Context, ts, pts *types.TipSet) ([]*lens.BlockMessageReceipts, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (aw *APIWrapper) CirculatingSupply(ctx context.Context, key types.TipSetKey) (api.CirculatingSupply, error) {
 	return aw.StateVMCirculatingSupplyInternal(ctx, key)
 }
@@ -35,14 +60,6 @@ func (aw *APIWrapper) ChainGetTipSetAfterHeight(ctx context.Context, epoch abi.C
 
 func (aw *APIWrapper) Store() adt.Store {
 	return aw
-}
-
-func (aw *APIWrapper) GetExecutedAndBlockMessagesForTipset(ctx context.Context, ts, pts *types.TipSet) (*lens.TipSetMessages, error) {
-	return nil, fmt.Errorf("ExecutedAndBlockMessages is not implemented")
-}
-
-func (aw *APIWrapper) GetMessageExecutionsForTipSet(ctx context.Context, ts, pts *types.TipSet) ([]*lens.MessageExecution, error) {
-	return nil, fmt.Errorf("MessageExecutions is not implemented")
 }
 
 func (aw *APIWrapper) Get(ctx context.Context, c cid.Cid, out interface{}) error {


### PR DESCRIPTION
### What
This PR removes the `ExecutedAndBlockMessages` method and replaces it smaller more specific methods: `TipSetMessageReceipts`, `TipSetBlockMessages`, and `ComputeGasOutputs`. 

While implementing, I noticed a few bugs in the now replaced `ExecutedAndBlockMessages` method, which are tracked in #1045 and #1043 and fixed in this PR. Furthermore, I took the opportunity to address #1041 while implementing `TipSetMessageReceipts`.