### PR TITLE
fix: use web3.storage gateway

### DIFF
--- a/itests/fetch/fetch.go
+++ b/itests/fetch/fetch.go
@@ -27,7 +27,7 @@ import (
 
 var log = logging.Logger("lily/vectors")
 
-const gateway = "https://dweb.link/ipfs/"
+const gateway = "https://ipfs.w3s.link/ipfs/"
 const lockFile = "fetch.lock"
 const vectordir = "/var/tmp/lily-test-vectors"
 const vectordirenv = "LILY_TEST_VECTORS"


### PR DESCRIPTION
use the web3 storage gateway to ensure vectors are always downloaded successfully. dweb gateway fails to serve content.