### PR TITLE
fix: Use bitfield.MultiMerge to improve LoadSectorState performance

### DIFF
--- a/tasks/actorstate/miner/sector_events.go
+++ b/tasks/actorstate/miner/sector_events.go
@@ -264,7 +264,7 @@ type SectorStates struct {
 // LoadSectorState loads all sectors from a miners partitions and returns a SectorStates structure containing individual
 // bitfields for all active, live, faulty and recovering sector.
 func LoadSectorState(ctx context.Context, state miner.State) (*SectorStates, error) {
-	ctx, span := otel.Tracer("").Start(ctx, "LoadSectorState")
+	_, span := otel.Tracer("").Start(ctx, "LoadSectorState")
 	defer span.End()
 
 	sectorStates := &SectorStates{}

--- a/tasks/actorstate/miner/sector_events.go
+++ b/tasks/actorstate/miner/sector_events.go
@@ -267,7 +267,6 @@ func LoadSectorState(ctx context.Context, state miner.State) (*SectorStates, err
 	_, span := otel.Tracer("").Start(ctx, "LoadSectorState")
 	defer span.End()
 
-	sectorStates := &SectorStates{}
 	activeSectors := []bitfield.BitField{}
 	liveSectors := []bitfield.BitField{}
 	faultySectors := []bitfield.BitField{}
@@ -306,6 +305,7 @@ func LoadSectorState(ctx context.Context, state miner.State) (*SectorStates, err
 		return nil, err
 	}
 	var err error
+	sectorStates := &SectorStates{}
 	if sectorStates.Active, err = bitfield.MultiMerge(activeSectors...); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Using bitfield.MultiMerge once instead of bitfield.MergeBitFields repeatedly should reduce the time by 50%.