### PR TITLE
fix: remove actor code mapping

### DIFF
--- a/lens/lily/impl.go
+++ b/lens/lily/impl.go
@@ -514,13 +514,13 @@ func (m *LilyNodeAPI) GetMessageExecutionsForTipSet(ctx context.Context, next *t
 
 	out := make([]*lens.MessageExecution, len(executions))
 	for idx, execution := range executions {
-		toCode, found := getActorCode(execution.Msg.To)
+		toCode, found := getActorCode(ctx, execution.Msg.To)
 		// if the message failed to execute due to lack of gas then the TO actor may never have been created.
 		if !found {
 			log.Warnw("failed to find TO actor", "height", next.Height().String(), "message", execution.Msg.Cid().String(), "actor", execution.Msg.To.String())
 		}
 		// if the message sender cannot be found this is an unexpected error
-		fromCode, found := getActorCode(execution.Msg.From)
+		fromCode, found := getActorCode(ctx, execution.Msg.From)
 		if !found {
 			return nil, fmt.Errorf("failed to find from actor %s height %d message %s", execution.Msg.From, execution.TipSet.Height(), execution.Msg.Cid())
 		}

--- a/lens/util/repo.go
+++ b/lens/util/repo.go
@@ -193,7 +193,7 @@ func MakeGetActorCodeFunc(ctx context.Context, store adt.Store, next, current *t
 		_, innerSpan := otel.Tracer("").Start(ctx, "GetActorCode")
 		defer innerSpan.End()
 
-		act, err := nextStateTree.GetActor(a)
+		act, _ := nextStateTree.GetActor(a)
 		if act != nil {
 			return act.Code, true
 		}
@@ -204,7 +204,7 @@ func MakeGetActorCodeFunc(ctx context.Context, store adt.Store, next, current *t
 			return cid.Undef, false
 		}
 
-		act, err = nextStateTree.GetActor(ra)
+		act, _ = nextStateTree.GetActor(ra)
 		if act != nil {
 			return act.Code, true
 		}

--- a/tasks/messageexecutions/vm/task.go
+++ b/tasks/messageexecutions/vm/task.go
@@ -58,7 +58,7 @@ func (t *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 		return nil
 	})
 
-	var getActorCode func(a address.Address) (cid.Cid, bool)
+	var getActorCode func(ctx context.Context, a address.Address) (cid.Cid, bool)
 	grp.Go(func() error {
 		var err error
 		getActorCode, err = util.MakeGetActorCodeFunc(ctx, t.node.Store(), current, executed)
@@ -101,7 +101,7 @@ func (t *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 			// Cid() computes a CID, so only call it once
 			childCid := child.Message.Cid()
 
-			toCode, found := getActorCode(child.Message.To)
+			toCode, found := getActorCode(ctx, child.Message.To)
 			if !found && child.Receipt.ExitCode == 0 {
 				// No destination actor code. Normally Lotus will create an account actor for unknown addresses but if the
 				// message fails then Lotus will not allow the actor to be created, and we are left with an address of an

--- a/tasks/messages/gasoutput/task.go
+++ b/tasks/messages/gasoutput/task.go
@@ -52,7 +52,7 @@ func (t *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 
 	grp, grpCtx := errgroup.WithContext(ctx)
 
-	var getActorCodeFn func(address address.Address) (cid.Cid, bool)
+	var getActorCodeFn func(ctx context.Context, address address.Address) (cid.Cid, bool)
 	grp.Go(func() error {
 		var err error
 		getActorCodeFn, err = util.MakeGetActorCodeFunc(grpCtx, t.node.Store(), current, executed)
@@ -113,7 +113,7 @@ func (t *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 			}
 			exeMsgSeen[m.Cid()] = true
 
-			toActorCode, found := getActorCodeFn(m.VMMessage().To)
+			toActorCode, found := getActorCodeFn(ctx, m.VMMessage().To)
 			if !found {
 				toActorCode = cid.Undef
 			}

--- a/tasks/messages/parsedmessage/task.go
+++ b/tasks/messages/parsedmessage/task.go
@@ -54,7 +54,7 @@ func (t *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 
 	grp, _ := errgroup.WithContext(ctx)
 
-	var getActorCodeFn func(address address.Address) (cid.Cid, bool)
+	var getActorCodeFn func(ctx context.Context, address address.Address) (cid.Cid, bool)
 	grp.Go(func() error {
 		var err error
 		getActorCodeFn, err = util.MakeGetActorCodeFunc(ctx, t.node.Store(), current, executed)
@@ -105,7 +105,7 @@ func (t *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 			}
 			exeMsgSeen[m.Cid()] = true
 
-			toActorCode, found := getActorCodeFn(m.VMMessage().To)
+			toActorCode, found := getActorCodeFn(ctx, m.VMMessage().To)
 			if !found && r.ExitCode == 0 {
 				// No destination actor code. Normally Lotus will create an account actor for unknown addresses but if the
 				// message fails then Lotus will not allow the actor to be created and we are left with an address of an

--- a/tasks/msapprovals/msapprovals.go
+++ b/tasks/msapprovals/msapprovals.go
@@ -59,7 +59,7 @@ func (p *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 
 	grp, _ := errgroup.WithContext(ctx)
 
-	var getActorCodeFn func(address address.Address) (cid.Cid, bool)
+	var getActorCodeFn func(ctx context.Context, address address.Address) (cid.Cid, bool)
 	grp.Go(func() error {
 		var err error
 		getActorCodeFn, err = util.MakeGetActorCodeFunc(ctx, p.node.Store(), current, executed)
@@ -108,7 +108,7 @@ func (p *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 			}
 
 			// Only interested in messages to multisig actors
-			msgToCode, found := getActorCodeFn(msg.VMMessage().To)
+			msgToCode, found := getActorCodeFn(ctx, msg.VMMessage().To)
 			if !found {
 				return nil, nil, fmt.Errorf("failed to find to actor %s height %d message %s", msg.VMMessage().To, current.Height(), msg.Cid())
 			}


### PR DESCRIPTION
Without actor code mapping, MakeGetActorCodeFunc & all GetActorCode calls only take a few ms to execute.
Time to construct actor code mapping with 5M state store caching takes ~10s.
Time to construct actor code mapping without caching takes ~40s.