### PR TITLE
fix(ci): Use a string matcher for the workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,7 +305,7 @@ jobs:
 # used in `build-docker-images` workflow below
 branch_filters: &branch_filters
   branches:
-    only: /^cd/staging$/
+    only: cd/staging
   tags:
     ignore: /.*/
 


### PR DESCRIPTION
CI is not triggering this job. In this, I try again by switching to a text matcher.