### PR TITLE
chore(docker): Cache proof params in production docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,10 @@ COPY --from=builder /usr/lib/x86_64-linux-gnu/libhwloc.so* /lib/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libnuma.so* /lib/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libltdl.so* /lib/
 
+RUN /usr/bin/lily init
+
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
-      jq
+RUN apt-get install -y --no-install-recommends jq
 
 ENTRYPOINT ["/usr/bin/lily"]
 CMD ["--help"]

--- a/build/docker/prod_entrypoint.tpl
+++ b/build/docker/prod_entrypoint.tpl
@@ -9,9 +9,10 @@ COPY --from=builder /usr/lib/x86_64-linux-gnu/libhwloc.so* /lib/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libnuma.so* /lib/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libltdl.so* /lib/
 
+RUN /usr/bin/lily init
+
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
-      jq
+RUN apt-get install -y --no-install-recommends jq
 
 ENTRYPOINT ["/usr/bin/lily"]
 CMD ["--help"]


### PR DESCRIPTION
closes https://github.com/filecoin-project/sentinel-infra/issues/408

Note the tradeoff here is a larger image (going from ~300MB to ~700MB) in exchange for shorter startup time and avoidance of potential future issues related to transient proof downloads.

(This also means that proof changes will require a new build/release.)