### PR TITLE
feat: add nonce column to actor_states

### DIFF
--- a/model/actors/common/actors.go
+++ b/model/actors/common/actors.go
@@ -79,6 +79,8 @@ type ActorState struct {
 	Code string `pg:",pk,notnull"`
 	// Top level of state data as json.
 	State string `pg:",type:jsonb,notnull"`
+	// The next Actor nonce that is expected to appear on chain.
+	Nonce uint64 `pg:",use_zero"`
 }
 
 func (as *ActorState) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {

--- a/schemas/v1/13_actorstates_nonce.go
+++ b/schemas/v1/13_actorstates_nonce.go
@@ -5,7 +5,8 @@ func init() {
 		13,
 		`
 ALTER TABLE {{ .SchemaName | default "public"}}.actor_states
-ADD COLUMN nonce BIGINT;
+  ADD COLUMN nonce BIGINT
+  ADD CONSTRAINT uniq_nullable_nonce UNIQUE (head,nonce);
 
 COMMENT ON COLUMN {{ .SchemaName | default "public"}}.actor_states.nonce IS 'The nonce of the actor expected to appear on the chain after the actor has been modified or created at each epoch. More precisely, this nonce tracks the number of messages sent by an actor.';
 `,

--- a/schemas/v1/13_actorstates_nonce.go
+++ b/schemas/v1/13_actorstates_nonce.go
@@ -2,7 +2,7 @@ package v1
 
 func init() {
 	patches.Register(
-		7,
+		13,
 		`
 ALTER TABLE {{ .SchemaName | default "public"}}.actor_states
 ADD COLUMN nonce BIGINT;

--- a/schemas/v1/13_actorstates_nonce.go
+++ b/schemas/v1/13_actorstates_nonce.go
@@ -6,7 +6,7 @@ func init() {
 		`
 ALTER TABLE {{ .SchemaName | default "public"}}.actor_states
   ADD COLUMN nonce BIGINT,
-  ADD CONSTRAINT uniq_nullable_nonce UNIQUE (head,nonce);
+  ADD CONSTRAINT uniq_nullable_nonce UNIQUE (height,head,nonce);
 
 COMMENT ON COLUMN {{ .SchemaName | default "public"}}.actor_states.nonce IS 'The nonce of the actor expected to appear on the chain after the actor has been modified or created at each epoch. More precisely, this nonce tracks the number of messages sent by an actor.';
 `,

--- a/schemas/v1/13_actorstates_nonce.go
+++ b/schemas/v1/13_actorstates_nonce.go
@@ -1,0 +1,13 @@
+package v1
+
+func init() {
+	patches.Register(
+		7,
+		`
+ALTER TABLE {{ .SchemaName | default "public"}}.actor_states
+ADD COLUMN nonce BIGINT;
+
+COMMENT ON COLUMN {{ .SchemaName | default "public"}}.actor_states.nonce IS 'The nonce of the actor expected to appear on the chain after the actor has been modified or created at each epoch. More precisely, this nonce tracks the number of messages sent by an actor.';
+`,
+	)
+}

--- a/schemas/v1/13_actorstates_nonce.go
+++ b/schemas/v1/13_actorstates_nonce.go
@@ -5,7 +5,7 @@ func init() {
 		13,
 		`
 ALTER TABLE {{ .SchemaName | default "public"}}.actor_states
-  ADD COLUMN nonce BIGINT
+  ADD COLUMN nonce BIGINT,
   ADD CONSTRAINT uniq_nullable_nonce UNIQUE (head,nonce);
 
 COMMENT ON COLUMN {{ .SchemaName | default "public"}}.actor_states.nonce IS 'The nonce of the actor expected to appear on the chain after the actor has been modified or created at each epoch. More precisely, this nonce tracks the number of messages sent by an actor.';

--- a/schemas/v1/13_actorstates_nonce.go
+++ b/schemas/v1/13_actorstates_nonce.go
@@ -6,7 +6,7 @@ func init() {
 		`
 ALTER TABLE {{ .SchemaName | default "public"}}.actor_states
   ADD COLUMN nonce BIGINT,
-  ADD CONSTRAINT uniq_nullable_nonce UNIQUE (height,head,nonce);
+  ADD CONSTRAINT actor_states_uniq_nullable_nonce UNIQUE (height,head,nonce);
 
 COMMENT ON COLUMN {{ .SchemaName | default "public"}}.actor_states.nonce IS 'The nonce of the actor expected to appear on the chain after the actor has been modified or created at each epoch. More precisely, this nonce tracks the number of messages sent by an actor.';
 `,

--- a/tasks/actorstate/raw/actor_state.go
+++ b/tasks/actorstate/raw/actor_state.go
@@ -43,5 +43,6 @@ func (RawActorStateExtractor) Extract(ctx context.Context, a actorstate.ActorInf
 		Head:   a.Actor.Head.String(),
 		Code:   a.Actor.Code.String(),
 		State:  string(state),
+		Nonce:  a.Actor.Nonce,
 	}, nil
 }


### PR DESCRIPTION
This PR:

- persists the actors nonce in the `actor_states` table and;
- adds the `nonce` column to the `actor_states` table in the schema.
  - the `nonce` column has a `UNIQUE` constraint on it but still nullable ([postgres docs](https://www.postgresql.org/docs/13/ddl-constraints.html#DDL-CONSTRAINTS-UNIQUE-CONSTRAINTS))
  - I didn't wanna make it into a PK bc we'll need to fill existing rows with some unique values and I don't see the need to create yet another table which will be added overhead for Lily users who are using Postgres for storage. Adding another table would mean creating a view to unify these two tables (`actor_states`) and (`actor_states_with_nonce`).

Resolves #1104 