### PR TITLE
chore: add unique constraint on vm_messages.params

### DIFF
--- a/schemas/v1/14_vm_messages_uniq_params.go
+++ b/schemas/v1/14_vm_messages_uniq_params.go
@@ -1,0 +1,11 @@
+package v1
+
+func init() {
+	patches.Register(
+		14,
+		`
+ALTER TABLE {{ .SchemaName | default "public"}}.vm_messages
+  ADD CONSTRAINT vm_messages_uniq_params UNIQUE (height, state_root, cid, source, params);
+`,
+	)
+}


### PR DESCRIPTION
Stacks on: #1105 (please review #1105 first before this one) 
Resolves: #1106

To prevent duplicate `vm_messages`, we can add a constraint on the `params`. 