### PR TITLE
chore: Add minimal support for v10 and v11 evm actors

### DIFF
--- a/chain/actors/actors.go
+++ b/chain/actors/actors.go
@@ -41,6 +41,7 @@ const (
 	SystemKey   = "system"
 	VerifregKey = "verifiedregistry"
 	DatacapKey  = "datacap"
+	EvmKey      = "evm"
 )
 
 // GetActorCodeID looks up a builtin actor's code CID by actor version and canonical actor name.

--- a/chain/actors/agen/generator/gen.go
+++ b/chain/actors/agen/generator/gen.go
@@ -27,6 +27,7 @@ var actors = map[string][]int{
 	"reward":   lotusactors.Versions,
 	"verifreg": lotusactors.Versions,
 	"datacap":  lotusactors.Versions[8:],
+	"evm":      lotusactors.Versions[10:],
 }
 
 func Gen() error {

--- a/chain/actors/builtin/evm/actor.go.template
+++ b/chain/actors/builtin/evm/actor.go.template
@@ -1,0 +1,57 @@
+
+package evm
+
+import (
+	"github.com/ipfs/go-cid"
+	"golang.org/x/xerrors"
+
+	actorstypes "github.com/filecoin-project/go-state-types/actors"
+	"github.com/filecoin-project/go-state-types/cbor"
+
+	"github.com/filecoin-project/lotus/chain/actors/adt"
+	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/go-state-types/manifest"
+
+	builtin{{.latestVersion}} "github.com/filecoin-project/go-state-types/builtin"
+
+    "github.com/filecoin-project/lily/chain/actors"
+    "github.com/filecoin-project/lotus/chain/actors/adt"
+    "github.com/filecoin-project/lotus/chain/types"
+	lotusactors "github.com/filecoin-project/lotus/chain/actors"
+)
+
+var Methods = builtin{{.latestVersion}}.MethodsEVM
+
+func Load(store adt.Store, act *types.Actor) (State, error) {
+	if name, av, ok := lotusactors.GetActorMetaByCode(act.Code); ok {
+       if name != actors.EvmKey {
+          return nil, xerrors.Errorf("actor code is not evm: %s", name)
+       }
+
+       switch av {
+            {{range .versions}}
+                case actorstypes.Version{{.}}:
+                     return load{{.}}(store, act.Head)
+            {{end}}
+       }
+	}
+
+	return nil, xerrors.Errorf("unknown actor code %s", act.Code)
+}
+
+func MakeState(store adt.Store, av actorstypes.Version, bytecode cid.Cid) (State, error) {
+	switch av {
+{{range .versions}}
+	case actorstypes.Version{{.}}:
+		return make{{.}}(store, bytecode)
+{{end}}
+	default: return nil, xerrors.Errorf("evm actor only valid for actors v10 and above, got %d", av)
+    }
+}
+
+type State interface {
+	cbor.Marshaler
+
+	Nonce() (uint64, error)
+	GetState() interface{}
+}

--- a/chain/actors/builtin/evm/evm.go
+++ b/chain/actors/builtin/evm/evm.go
@@ -1,0 +1,57 @@
+package evm
+
+import (
+	"github.com/ipfs/go-cid"
+	"golang.org/x/xerrors"
+
+	actorstypes "github.com/filecoin-project/go-state-types/actors"
+	"github.com/filecoin-project/go-state-types/cbor"
+
+	"github.com/filecoin-project/go-state-types/manifest"
+	"github.com/filecoin-project/lotus/chain/actors/adt"
+	"github.com/filecoin-project/lotus/chain/types"
+
+	builtin11 "github.com/filecoin-project/go-state-types/builtin"
+
+	"github.com/filecoin-project/lily/chain/actors"
+	lotusactors "github.com/filecoin-project/lotus/chain/actors"
+	"github.com/filecoin-project/lotus/chain/actors/adt"
+	"github.com/filecoin-project/lotus/chain/types"
+)
+
+var Methods = builtin11.MethodsEVM
+
+func Load(store adt.Store, act *types.Actor) (State, error) {
+	if name, av, ok := lotusactors.GetActorMetaByCode(act.Code); ok {
+		if name != actors.EvmKey {
+			return nil, xerrors.Errorf("actor code is not evm: %s", name)
+		}
+
+		switch av {
+
+		case actorstypes.Version11:
+			return load11(store, act.Head)
+
+		}
+	}
+
+	return nil, xerrors.Errorf("unknown actor code %s", act.Code)
+}
+
+func MakeState(store adt.Store, av actorstypes.Version, bytecode cid.Cid) (State, error) {
+	switch av {
+
+	case actorstypes.Version11:
+		return make11(store, bytecode)
+
+	default:
+		return nil, xerrors.Errorf("evm actor only valid for actors v10 and above, got %d", av)
+	}
+}
+
+type State interface {
+	cbor.Marshaler
+
+	Nonce() (uint64, error)
+	GetState() interface{}
+}

--- a/chain/actors/builtin/evm/state.go.template
+++ b/chain/actors/builtin/evm/state.go.template
@@ -1,0 +1,45 @@
+package evm
+
+import (
+	"github.com/ipfs/go-cid"
+
+	"github.com/filecoin-project/lotus/chain/actors/adt"
+
+	evm{{.v}} "github.com/filecoin-project/go-state-types/builtin{{.import}}evm"
+)
+
+var _ State = (*state{{.v}})(nil)
+
+func load{{.v}}(store adt.Store, root cid.Cid) (State, error) {
+	out := state{{.v}}{store: store}
+	err := store.Get(store.Context(), root, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func make{{.v}}(store adt.Store, bytecode cid.Cid) (State, error) {
+	out := state{{.v}}{store: store}
+    s, err := evm{{.v}}.ConstructState(store, bytecode)
+    if err != nil {
+        return nil, err
+    }
+
+    out.State = *s
+
+	return &out, nil
+}
+
+type state{{.v}} struct {
+	evm{{.v}}.State
+	store adt.Store
+}
+
+func (s *state{{.v}}) Nonce() (uint64, error) {
+	return s.State.Nonce, nil
+}
+
+func (s *state{{.v}}) GetState() interface{} {
+	return &s.State
+}

--- a/chain/actors/builtin/evm/v10.go
+++ b/chain/actors/builtin/evm/v10.go
@@ -1,0 +1,45 @@
+package evm
+
+import (
+	"github.com/ipfs/go-cid"
+
+	evm10 "github.com/filecoin-project/go-state-types/builtin/v10/evm"
+
+	"github.com/filecoin-project/lotus/chain/actors/adt"
+)
+
+var _ State = (*state10)(nil)
+
+func load10(store adt.Store, root cid.Cid) (State, error) {
+	out := state10{store: store}
+	err := store.Get(store.Context(), root, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func make10(store adt.Store, bytecode cid.Cid) (State, error) {
+	out := state10{store: store}
+	s, err := evm10.ConstructState(store, bytecode)
+	if err != nil {
+		return nil, err
+	}
+
+	out.State = *s
+
+	return &out, nil
+}
+
+type state10 struct {
+	evm10.State
+	store adt.Store
+}
+
+func (s *state10) Nonce() (uint64, error) {
+	return s.State.Nonce, nil
+}
+
+func (s *state10) GetState() interface{} {
+	return &s.State
+}

--- a/chain/actors/builtin/evm/v11.go
+++ b/chain/actors/builtin/evm/v11.go
@@ -1,0 +1,45 @@
+package evm
+
+import (
+	"github.com/ipfs/go-cid"
+
+	"github.com/filecoin-project/lotus/chain/actors/adt"
+
+	evm11 "github.com/filecoin-project/go-state-types/builtin/v11/evm"
+)
+
+var _ State = (*state11)(nil)
+
+func load11(store adt.Store, root cid.Cid) (State, error) {
+	out := state11{store: store}
+	err := store.Get(store.Context(), root, &out)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func make11(store adt.Store, bytecode cid.Cid) (State, error) {
+	out := state11{store: store}
+	s, err := evm11.ConstructState(store, bytecode)
+	if err != nil {
+		return nil, err
+	}
+
+	out.State = *s
+
+	return &out, nil
+}
+
+type state11 struct {
+	evm11.State
+	store adt.Store
+}
+
+func (s *state11) Nonce() (uint64, error) {
+	return s.State.Nonce, nil
+}
+
+func (s *state11) GetState() interface{} {
+	return &s.State
+}


### PR DESCRIPTION
Lily is missing this builtin actor which, I think, is the reason why the walks from my comment regarding not being able to decode [`InvokeContract fil/10/evm`](https://github.com/filecoin-project/lily/pull/1114#issuecomment-1408107588).

This is a copy-pasta from Lotus.