### PR TITLE
feat: Override user-agent to lily

### DIFF
--- a/commands/daemon.go
+++ b/commands/daemon.go
@@ -262,7 +262,7 @@ Note that jobs are not persisted between restarts of the daemon. See
 			node.Override(new(dtypes.Bootstrapper), isBootstrapper),
 			node.Override(new(dtypes.ShutdownChan), shutdown),
 			node.Base(),
-			node.Override(node.UserAgentKey, lp2p.UserAgentOption("lily-"+version.String())), // Add a version?
+			node.Override(node.UserAgentKey, lp2p.UserAgentOption("lily-"+version.String())),
 			node.Repo(r),
 
 			node.Override(new(dtypes.UniversalBlockstore), modules.NewCachingUniversalBlockstore),

--- a/commands/daemon.go
+++ b/commands/daemon.go
@@ -16,6 +16,7 @@ import (
 	"github.com/filecoin-project/lotus/node"
 	lotusmodules "github.com/filecoin-project/lotus/node/modules"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
+	"github.com/filecoin-project/lotus/node/modules/lp2p"
 	"github.com/filecoin-project/lotus/node/repo"
 	"github.com/mitchellh/go-homedir"
 	"github.com/multiformats/go-multiaddr"
@@ -261,6 +262,7 @@ Note that jobs are not persisted between restarts of the daemon. See
 			node.Override(new(dtypes.Bootstrapper), isBootstrapper),
 			node.Override(new(dtypes.ShutdownChan), shutdown),
 			node.Base(),
+			node.Override(node.UserAgentKey, lp2p.UserAgentOption("lily-"+version.String())), // Add a version?
 			node.Repo(r),
 
 			node.Override(new(dtypes.UniversalBlockstore), modules.NewCachingUniversalBlockstore),

--- a/itests/node.go
+++ b/itests/node.go
@@ -75,7 +75,7 @@ func NewTestNode(ctx context.Context, t testing.TB, cfg *TestNodeConfig) (lily.L
 		node.Override(new(dtypes.Bootstrapper), false),
 		node.Override(new(dtypes.ShutdownChan), shutdown),
 		node.Base(),
-		node.Override(node.UserAgentKey, lp2p.UserAgentOption),
+		node.Override(node.UserAgentKey, lp2p.UserAgentOption("lily")), // Add a version?
 		node.Repo(r),
 
 		node.Override(new(dtypes.UniversalBlockstore), modules.NewCachingUniversalBlockstore),

--- a/itests/node.go
+++ b/itests/node.go
@@ -12,6 +12,7 @@ import (
 	"github.com/filecoin-project/lotus/node"
 	lotusmodules "github.com/filecoin-project/lotus/node/modules"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
+	lp2p "github.com/filecoin-project/lotus/node/modules/lp2p"
 	"github.com/filecoin-project/lotus/node/repo"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
@@ -74,6 +75,7 @@ func NewTestNode(ctx context.Context, t testing.TB, cfg *TestNodeConfig) (lily.L
 		node.Override(new(dtypes.Bootstrapper), false),
 		node.Override(new(dtypes.ShutdownChan), shutdown),
 		node.Base(),
+		node.Override(node.UserAgentKey, lp2p.UserAgentOption),
 		node.Repo(r),
 
 		node.Override(new(dtypes.UniversalBlockstore), modules.NewCachingUniversalBlockstore),

--- a/itests/node.go
+++ b/itests/node.go
@@ -12,7 +12,6 @@ import (
 	"github.com/filecoin-project/lotus/node"
 	lotusmodules "github.com/filecoin-project/lotus/node/modules"
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
-	lp2p "github.com/filecoin-project/lotus/node/modules/lp2p"
 	"github.com/filecoin-project/lotus/node/repo"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
@@ -75,7 +74,6 @@ func NewTestNode(ctx context.Context, t testing.TB, cfg *TestNodeConfig) (lily.L
 		node.Override(new(dtypes.Bootstrapper), false),
 		node.Override(new(dtypes.ShutdownChan), shutdown),
 		node.Base(),
-		node.Override(node.UserAgentKey, lp2p.UserAgentOption("lily")), // Add a version?
 		node.Repo(r),
 
 		node.Override(new(dtypes.UniversalBlockstore), modules.NewCachingUniversalBlockstore),


### PR DESCRIPTION
Dependent on https://github.com/filecoin-project/lotus/pull/10149 which has been merged, but no new release yet. What's the usual strategy here? Wait for the new release, or is there a way to somehow cherry pick the change? @frrist 