### PR TITLE
fix: Fix tipset cache bug with SetCurrent

### DIFF
--- a/chain/cache/tipset.go
+++ b/chain/cache/tipset.go
@@ -112,7 +112,7 @@ func (c *TipSetCache) SetCurrent(ts *types.TipSet) error {
 		_, err := c.Add(ts)
 		return err
 	}
-
+	c.idxHead = normalModulo(c.idxHead+1, len(c.buffer))
 	c.buffer[c.idxHead] = ts
 	return nil
 }

--- a/chain/cache/tipset.go
+++ b/chain/cache/tipset.go
@@ -112,6 +112,7 @@ func (c *TipSetCache) SetCurrent(ts *types.TipSet) error {
 		_, err := c.Add(ts)
 		return err
 	}
+	
 	c.buffer[c.idxHead] = ts
 	return nil
 }

--- a/chain/cache/tipset.go
+++ b/chain/cache/tipset.go
@@ -112,7 +112,7 @@ func (c *TipSetCache) SetCurrent(ts *types.TipSet) error {
 		_, err := c.Add(ts)
 		return err
 	}
-	
+
 	c.buffer[c.idxHead] = ts
 	return nil
 }

--- a/chain/cache/tipset.go
+++ b/chain/cache/tipset.go
@@ -112,7 +112,6 @@ func (c *TipSetCache) SetCurrent(ts *types.TipSet) error {
 		_, err := c.Add(ts)
 		return err
 	}
-	c.idxHead = normalModulo(c.idxHead+1, len(c.buffer))
 	c.buffer[c.idxHead] = ts
 	return nil
 }
@@ -179,6 +178,10 @@ func (c *TipSetCache) Warm(ctx context.Context, head *types.TipSet, getTipSetFn 
 		if expectNil != nil {
 			return fmt.Errorf("unexpected tipset returned while warming tipset cache: %s", expectNil)
 		}
+	}
+	err := c.SetCurrent(head)
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/chain/cache/tipset_test.go
+++ b/chain/cache/tipset_test.go
@@ -416,7 +416,7 @@ func TestTipSetCacheSetCurrent(t *testing.T) {
 		assert.Same(t, ts12, head)
 	})
 
-	t.Run("higher height", func(t *testing.T) {
+	t.Run("higher height removes lowest height", func(t *testing.T) {
 		c := NewTipSetCache(3)
 
 		ts14 := mustMakeTs(nil, 14, dummyCid)
@@ -430,20 +430,32 @@ func TestTipSetCacheSetCurrent(t *testing.T) {
 		assert.Equal(t, 2, c.Len())
 
 		ts16 := mustMakeTs(nil, 16, dummyCid)
-		_, err = c.Add(ts16)
-		assert.NoError(t, err)
-		assert.Equal(t, 3, c.Len())
-
-		ts17 := mustMakeTs(nil, 17, dummyCid)
-		err = c.SetCurrent(ts17)
-		assert.NoError(t, err)
-		assert.Equal(t, 3, c.Len())
+		err = c.SetCurrent(ts16)
+		require.NoError(t, err)
+		assert.Equal(t, 2, c.Len())
 
 		head, err := c.Head()
 		require.NoError(t, err)
-		assert.Same(t, ts17, head)
-		assert.Same(t, ts16, c.buffer[normalModulo(c.idxHead-1, c.Len())])
-		assert.Same(t, ts15, c.buffer[normalModulo(c.idxHead-2, c.Len())])
+		assert.Same(t, ts16, head)
+		assert.Same(t, ts15, c.buffer[normalModulo(c.idxHead-1, c.Len())])
+
+		ts17 := mustMakeTs(nil, 17, dummyCid)
+		_, err = c.Add(ts17)
+		require.NoError(t, err)
+		assert.Equal(t, t, 3, c.Len())
+
+		ts18 := mustMakeTs(nil, 18, dummyCid)
+		err = c.SetCurrent(ts18)
+		require.NoError(t, err)
+
+		head, err = c.Head()
+		assert.Same(t, ts18, head)
+		assert.Same(t, ts17, c.buffer[normalModulo(c.idxHead-1, c.Len())])
+		assert.Same(t, ts16, c.buffer[normalModulo(c.idxHead-2, c.Len())])
+
+		tail, err := c.Tail()
+		require.NoError(t, err)
+		assert.Same(t, ts16, tail)
 	})
 }
 

--- a/chain/cache/tipset_test.go
+++ b/chain/cache/tipset_test.go
@@ -415,48 +415,6 @@ func TestTipSetCacheSetCurrent(t *testing.T) {
 		require.NoError(t, err)
 		assert.Same(t, ts12, head)
 	})
-
-	t.Run("higher height removes lowest height", func(t *testing.T) {
-		c := NewTipSetCache(3)
-
-		ts14 := mustMakeTs(nil, 14, dummyCid)
-		_, err := c.Add(ts14)
-		require.NoError(t, err)
-		assert.Equal(t, 1, c.Len())
-
-		ts15 := mustMakeTs(nil, 15, dummyCid)
-		_, err = c.Add(ts15)
-		require.NoError(t, err)
-		assert.Equal(t, 2, c.Len())
-
-		ts16 := mustMakeTs(nil, 16, dummyCid)
-		err = c.SetCurrent(ts16)
-		require.NoError(t, err)
-		assert.Equal(t, 2, c.Len())
-
-		head, err := c.Head()
-		require.NoError(t, err)
-		assert.Same(t, ts16, head)
-		assert.Same(t, ts15, c.buffer[normalModulo(c.idxHead-1, c.Len())])
-
-		ts17 := mustMakeTs(nil, 17, dummyCid)
-		_, err = c.Add(ts17)
-		require.NoError(t, err)
-		assert.Equal(t, 3, c.Len())
-
-		ts18 := mustMakeTs(nil, 18, dummyCid)
-		err = c.SetCurrent(ts18)
-		require.NoError(t, err)
-
-		head, err = c.Head()
-		assert.Same(t, ts18, head)
-		assert.Same(t, ts17, c.buffer[normalModulo(c.idxHead-1, c.Len())])
-		assert.Same(t, ts16, c.buffer[normalModulo(c.idxHead-2, c.Len())])
-
-		tail, err := c.Tail()
-		require.NoError(t, err)
-		assert.Same(t, ts16, tail)
-	})
 }
 
 func TestTipSetCacheAddOnlyReturnsOldTailWhenFull(t *testing.T) {
@@ -507,6 +465,10 @@ func TestTipSetCacheWarming(t *testing.T) {
 		err := c.Warm(context.Background(), head, tw.GetTipSet)
 		assert.NoError(t, err)
 
+		expectHead, err := c.Head()
+		assert.NoError(t, err)
+		assert.Equal(t, expectHead, head)
+
 		newHead := mustMakeTs(head.Cids(), 15, dummyCid)
 		expectC4, err := c.Add(newHead)
 		assert.NoError(t, err)
@@ -539,6 +501,10 @@ func TestTipSetCacheWarming(t *testing.T) {
 
 		err := c.Warm(context.Background(), head, tw.GetTipSet)
 		assert.NoError(t, err)
+
+		expectHead, err := c.Head()
+		assert.NoError(t, err)
+		assert.Equal(t, expectHead, head)
 
 		expectNil, err := c.Add(mustMakeTs(head.Cids(), 15, dummyCid))
 		assert.NoError(t, err)

--- a/chain/cache/tipset_test.go
+++ b/chain/cache/tipset_test.go
@@ -415,6 +415,36 @@ func TestTipSetCacheSetCurrent(t *testing.T) {
 		require.NoError(t, err)
 		assert.Same(t, ts12, head)
 	})
+
+	t.Run("higher height", func(t *testing.T) {
+		c := NewTipSetCache(3)
+
+		ts14 := mustMakeTs(nil, 14, dummyCid)
+		_, err := c.Add(ts14)
+		require.NoError(t, err)
+		assert.Equal(t, 1, c.Len())
+
+		ts15 := mustMakeTs(nil, 15, dummyCid)
+		_, err = c.Add(ts15)
+		require.NoError(t, err)
+		assert.Equal(t, 2, c.Len())
+
+		ts16 := mustMakeTs(nil, 16, dummyCid)
+		_, err = c.Add(ts16)
+		assert.NoError(t, err)
+		assert.Equal(t, 3, c.Len())
+
+		ts17 := mustMakeTs(nil, 17, dummyCid)
+		err = c.SetCurrent(ts17)
+		assert.NoError(t, err)
+		assert.Equal(t, 3, c.Len())
+
+		head, err := c.Head()
+		require.NoError(t, err)
+		assert.Same(t, ts17, head)
+		assert.Same(t, ts16, c.buffer[normalModulo(c.idxHead-1, c.Len())])
+		assert.Same(t, ts15, c.buffer[normalModulo(c.idxHead-2, c.Len())])
+	})
 }
 
 func TestTipSetCacheAddOnlyReturnsOldTailWhenFull(t *testing.T) {

--- a/chain/cache/tipset_test.go
+++ b/chain/cache/tipset_test.go
@@ -442,7 +442,7 @@ func TestTipSetCacheSetCurrent(t *testing.T) {
 		ts17 := mustMakeTs(nil, 17, dummyCid)
 		_, err = c.Add(ts17)
 		require.NoError(t, err)
-		assert.Equal(t, t, 3, c.Len())
+		assert.Equal(t, 3, c.Len())
 
 		ts18 := mustMakeTs(nil, 18, dummyCid)
 		err = c.SetCurrent(ts18)


### PR DESCRIPTION
Addresses the bug in: https://github.com/filecoin-project/lily/issues/1083.