### PR TITLE
[command] add currentheight to job list

### DIFF
--- a/chain/gap/fill.go
+++ b/chain/gap/fill.go
@@ -26,10 +26,10 @@ type Filler struct {
 	minHeight, maxHeight int64
 	tasks                []string
 	done                 chan struct{}
-	config               *schedule.JobConfig
+	report               *schedule.Reporter
 }
 
-func NewFiller(node lens.API, db *storage.Database, name string, minHeight, maxHeight int64, tasks []string, config *schedule.JobConfig) *Filler {
+func NewFiller(node lens.API, db *storage.Database, name string, minHeight, maxHeight int64, tasks []string, r *schedule.Reporter) *Filler {
 	return &Filler{
 		DB:        db,
 		node:      node,
@@ -37,7 +37,7 @@ func NewFiller(node lens.API, db *storage.Database, name string, minHeight, maxH
 		maxHeight: maxHeight,
 		minHeight: minHeight,
 		tasks:     tasks,
-		config:    config,
+		report:    r,
 	}
 }
 
@@ -72,7 +72,7 @@ func (g *Filler) Run(ctx context.Context) error {
 		runStart := time.Now()
 
 		log.Infow("filling gap", "height", heights, "reporter", g.name)
-		g.config.UpdateCurrentHeight(int(height))
+		g.report.UpdateCurrentHeight(int(height))
 		ts, err := g.node.ChainGetTipSetByHeight(ctx, abi.ChainEpoch(height), types.EmptyTSK)
 		if err != nil {
 			return err

--- a/chain/gap/fill.go
+++ b/chain/gap/fill.go
@@ -72,7 +72,7 @@ func (g *Filler) Run(ctx context.Context) error {
 		runStart := time.Now()
 
 		log.Infow("filling gap", "height", heights, "reporter", g.name)
-		g.report.UpdateCurrentHeight(int(height))
+		g.report.UpdateCurrentHeight(int64(height))
 		ts, err := g.node.ChainGetTipSetByHeight(ctx, abi.ChainEpoch(height), types.EmptyTSK)
 		if err != nil {
 			return err

--- a/chain/gap/fill.go
+++ b/chain/gap/fill.go
@@ -13,6 +13,7 @@ import (
 	"github.com/filecoin-project/lily/chain/indexer/integrated"
 	"github.com/filecoin-project/lily/chain/indexer/integrated/tipset"
 	"github.com/filecoin-project/lily/lens"
+	"github.com/filecoin-project/lily/schedule"
 	"github.com/filecoin-project/lily/storage"
 )
 
@@ -25,9 +26,10 @@ type Filler struct {
 	minHeight, maxHeight int64
 	tasks                []string
 	done                 chan struct{}
+	config               *schedule.JobConfig
 }
 
-func NewFiller(node lens.API, db *storage.Database, name string, minHeight, maxHeight int64, tasks []string) *Filler {
+func NewFiller(node lens.API, db *storage.Database, name string, minHeight, maxHeight int64, tasks []string, config *schedule.JobConfig) *Filler {
 	return &Filler{
 		DB:        db,
 		node:      node,
@@ -35,6 +37,7 @@ func NewFiller(node lens.API, db *storage.Database, name string, minHeight, maxH
 		maxHeight: maxHeight,
 		minHeight: minHeight,
 		tasks:     tasks,
+		config:    config,
 	}
 }
 
@@ -69,7 +72,7 @@ func (g *Filler) Run(ctx context.Context) error {
 		runStart := time.Now()
 
 		log.Infow("filling gap", "height", heights, "reporter", g.name)
-
+		g.config.UpdateCurrentHeight(int(height))
 		ts, err := g.node.ChainGetTipSetByHeight(ctx, abi.ChainEpoch(height), types.EmptyTSK)
 		if err != nil {
 			return err

--- a/chain/gap/fill.go
+++ b/chain/gap/fill.go
@@ -72,7 +72,7 @@ func (g *Filler) Run(ctx context.Context) error {
 		runStart := time.Now()
 
 		log.Infow("filling gap", "height", heights, "reporter", g.name)
-		g.report.UpdateCurrentHeight(int64(height))
+		g.report.UpdateCurrentHeight(height)
 		ts, err := g.node.ChainGetTipSetByHeight(ctx, abi.ChainEpoch(height), types.EmptyTSK)
 		if err != nil {
 			return err

--- a/chain/walk/walker.go
+++ b/chain/walk/walker.go
@@ -99,7 +99,7 @@ func (c *Walker) WalkChain(ctx context.Context, node lens.API, ts *types.TipSet)
 		default:
 		}
 		log.Infow("walk tipset", "height", ts.Height(), "reporter", c.name)
-		c.report.UpdateCurrentHeight(int(ts.Height()))
+		c.report.UpdateCurrentHeight(int64(ts.Height()))
 		if success, err := c.obs.TipSet(ctx, ts, indexer.WithIndexerType(indexer.Walk), indexer.WithTasks(c.tasks)); err != nil {
 			span.RecordError(err)
 			return fmt.Errorf("notify tipset: %w", err)

--- a/chain/walk/walker.go
+++ b/chain/walk/walker.go
@@ -100,7 +100,7 @@ func (c *Walker) WalkChain(ctx context.Context, node lens.API, ts *types.TipSet)
 		default:
 		}
 		log.Infow("walk tipset", "height", ts.Height(), "reporter", c.name)
-		c.config.CurrentHeight = int(ts.Height())
+		c.config.UpdateCurrentHeight(int(ts.Height()))
 		if success, err := c.obs.TipSet(ctx, ts, indexer.WithIndexerType(indexer.Walk), indexer.WithTasks(c.tasks)); err != nil {
 			span.RecordError(err)
 			return fmt.Errorf("notify tipset: %w", err)

--- a/chain/walk/walker_test.go
+++ b/chain/walk/walker_test.go
@@ -55,8 +55,8 @@ func TestWalker(t *testing.T) {
 	require.NoError(t, err, "NewManager")
 
 	t.Logf("initializing indexer")
-	jobConfig := &schedule.JobConfig{}
-	idx := NewWalker(im, nodeAPI, t.Name(), []string{tasktype.BlocksTask}, 0, int64(head.Height()), jobConfig)
+	reporter := &schedule.Reporter{}
+	idx := NewWalker(im, nodeAPI, t.Name(), []string{tasktype.BlocksTask}, 0, int64(head.Height()), reporter)
 
 	t.Logf("indexing chain")
 	err = idx.WalkChain(ctx, nodeAPI, head)

--- a/chain/walk/walker_test.go
+++ b/chain/walk/walker_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/filecoin-project/lily/chain/indexer/integrated/tipset"
 	"github.com/filecoin-project/lily/chain/indexer/tasktype"
 	"github.com/filecoin-project/lily/model/blocks"
+	"github.com/filecoin-project/lily/schedule"
 	"github.com/filecoin-project/lily/storage"
 	"github.com/filecoin-project/lily/testutil"
 )
@@ -54,7 +55,8 @@ func TestWalker(t *testing.T) {
 	require.NoError(t, err, "NewManager")
 
 	t.Logf("initializing indexer")
-	idx := NewWalker(im, nodeAPI, t.Name(), []string{tasktype.BlocksTask}, 0, int64(head.Height()))
+	jobConfig := &schedule.JobConfig{}
+	idx := NewWalker(im, nodeAPI, t.Name(), []string{tasktype.BlocksTask}, 0, int64(head.Height()), jobConfig)
 
 	t.Logf("indexing chain")
 	err = idx.WalkChain(ctx, nodeAPI, head)

--- a/chain/watch/watcher.go
+++ b/chain/watch/watcher.go
@@ -238,7 +238,7 @@ func (c *Watcher) indexTipSetAsync(ctx context.Context, ts *types.TipSet) error 
 		log.Warnw("queuing worker in watcher pool", "waiting", c.pool.WaitingQueueSize(), "reporter", c.name)
 	}
 	log.Infow("submitting tipset for async indexing", "height", ts.Height(), "active", c.active, "reporter", c.name)
-	c.report.UpdateCurrentHeight(int(ts.Height()))
+	c.report.UpdateCurrentHeight(int64(ts.Height()))
 	ctx, span := otel.Tracer("").Start(ctx, "Watcher.indexTipSetAsync")
 	c.pool.Submit(func() {
 		atomic.AddInt64(&c.active, 1)

--- a/chain/watch/watcher.go
+++ b/chain/watch/watcher.go
@@ -76,7 +76,7 @@ type Watcher struct {
 
 	// metric tracking
 	active int64 // must be accessed using atomic operations, updated automatically.
-	config *schedule.JobConfig
+	report *schedule.Reporter
 
 	// error handling
 	fatalMu sync.Mutex
@@ -93,7 +93,7 @@ var (
 // NewWatcher creates a new Watcher. confidence sets the number of tipsets that will be held
 // in a cache awaiting possible reversion. Tipsets will be written to the database when they are evicted from
 // the cache due to incoming later tipsets.
-func NewWatcher(api WatcherAPI, indexer indexer.Indexer, name string, config *schedule.JobConfig, opts ...WatcherOpt) *Watcher {
+func NewWatcher(api WatcherAPI, indexer indexer.Indexer, name string, r *schedule.Reporter, opts ...WatcherOpt) *Watcher {
 	w := &Watcher{
 		api:     api,
 		name:    name,
@@ -103,7 +103,7 @@ func NewWatcher(api WatcherAPI, indexer indexer.Indexer, name string, config *sc
 		confidence: WatcherDefaultConfidence,
 		poolSize:   WatcherDefaultConcurrentWorkers,
 		tasks:      WatcherDefaultTasks,
-		config:     config,
+		report:     r,
 	}
 
 	for _, opt := range opts {
@@ -238,7 +238,7 @@ func (c *Watcher) indexTipSetAsync(ctx context.Context, ts *types.TipSet) error 
 		log.Warnw("queuing worker in watcher pool", "waiting", c.pool.WaitingQueueSize(), "reporter", c.name)
 	}
 	log.Infow("submitting tipset for async indexing", "height", ts.Height(), "active", c.active, "reporter", c.name)
-	c.config.UpdateCurrentHeight(int(ts.Height()))
+	c.report.UpdateCurrentHeight(int(ts.Height()))
 	ctx, span := otel.Tracer("").Start(ctx, "Watcher.indexTipSetAsync")
 	c.pool.Submit(func() {
 		atomic.AddInt64(&c.active, 1)

--- a/chain/watch/watcher.go
+++ b/chain/watch/watcher.go
@@ -18,6 +18,7 @@ import (
 	"github.com/filecoin-project/lily/chain/indexer"
 	"github.com/filecoin-project/lily/chain/indexer/tasktype"
 	"github.com/filecoin-project/lily/metrics"
+	"github.com/filecoin-project/lily/schedule"
 )
 
 var log = logging.Logger("lily/chain/watch")
@@ -75,6 +76,7 @@ type Watcher struct {
 
 	// metric tracking
 	active int64 // must be accessed using atomic operations, updated automatically.
+	config *schedule.JobConfig
 
 	// error handling
 	fatalMu sync.Mutex
@@ -91,7 +93,7 @@ var (
 // NewWatcher creates a new Watcher. confidence sets the number of tipsets that will be held
 // in a cache awaiting possible reversion. Tipsets will be written to the database when they are evicted from
 // the cache due to incoming later tipsets.
-func NewWatcher(api WatcherAPI, indexer indexer.Indexer, name string, opts ...WatcherOpt) *Watcher {
+func NewWatcher(api WatcherAPI, indexer indexer.Indexer, name string, config *schedule.JobConfig, opts ...WatcherOpt) *Watcher {
 	w := &Watcher{
 		api:     api,
 		name:    name,
@@ -101,6 +103,7 @@ func NewWatcher(api WatcherAPI, indexer indexer.Indexer, name string, opts ...Wa
 		confidence: WatcherDefaultConfidence,
 		poolSize:   WatcherDefaultConcurrentWorkers,
 		tasks:      WatcherDefaultTasks,
+		config:     config,
 	}
 
 	for _, opt := range opts {
@@ -235,7 +238,7 @@ func (c *Watcher) indexTipSetAsync(ctx context.Context, ts *types.TipSet) error 
 		log.Warnw("queuing worker in watcher pool", "waiting", c.pool.WaitingQueueSize(), "reporter", c.name)
 	}
 	log.Infow("submitting tipset for async indexing", "height", ts.Height(), "active", c.active, "reporter", c.name)
-
+	c.config.UpdateCurrentHeight(int(ts.Height()))
 	ctx, span := otel.Tracer("").Start(ctx, "Watcher.indexTipSetAsync")
 	c.pool.Submit(func() {
 		atomic.AddInt64(&c.active, 1)

--- a/chain/watch/watcher_test.go
+++ b/chain/watch/watcher_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/filecoin-project/lily/chain/indexer/integrated/tipset"
 	"github.com/filecoin-project/lily/chain/indexer/tasktype"
 	"github.com/filecoin-project/lily/model/blocks"
+	"github.com/filecoin-project/lily/schedule"
 	"github.com/filecoin-project/lily/storage"
 	"github.com/filecoin-project/lily/testutil"
 )
@@ -81,7 +82,8 @@ func TestWatcher(t *testing.T) {
 	im, err := integrated.NewManager(strg, tipset.NewBuilder(taskAPI, t.Name()), integrated.WithWindow(builtin.EpochDurationSeconds*time.Second))
 	require.NoError(t, err, "NewManager")
 	t.Logf("initializing indexer")
-	idx := NewWatcher(nil, im, t.Name(), WithConfidence(0), WithConcurrentWorkers(1), WithBufferSize(5), WithTasks(tasktype.BlocksTask))
+	jobConfig := &schedule.JobConfig{}
+	idx := NewWatcher(nil, im, t.Name(), jobConfig, WithConfidence(0), WithConcurrentWorkers(1), WithBufferSize(5), WithTasks(tasktype.BlocksTask))
 	idx.cache = cache.NewTipSetCache(0)
 	// the watchers worker pool and cache are initialized in its Run method, since we don't call that here initialize them now.
 	idx.pool = workerpool.New(1)

--- a/chain/watch/watcher_test.go
+++ b/chain/watch/watcher_test.go
@@ -82,8 +82,8 @@ func TestWatcher(t *testing.T) {
 	im, err := integrated.NewManager(strg, tipset.NewBuilder(taskAPI, t.Name()), integrated.WithWindow(builtin.EpochDurationSeconds*time.Second))
 	require.NoError(t, err, "NewManager")
 	t.Logf("initializing indexer")
-	jobConfig := &schedule.JobConfig{}
-	idx := NewWatcher(nil, im, t.Name(), jobConfig, WithConfidence(0), WithConcurrentWorkers(1), WithBufferSize(5), WithTasks(tasktype.BlocksTask))
+	reporter := &schedule.Reporter{}
+	idx := NewWatcher(nil, im, t.Name(), reporter, WithConfidence(0), WithConcurrentWorkers(1), WithBufferSize(5), WithTasks(tasktype.BlocksTask))
 	idx.cache = cache.NewTipSetCache(0)
 	// the watchers worker pool and cache are initialized in its Run method, since we don't call that here initialize them now.
 	idx.pool = workerpool.New(1)

--- a/lens/lily/api.go
+++ b/lens/lily/api.go
@@ -90,6 +90,8 @@ type LilyJobConfig struct {
 	RestartDelay time.Duration
 	// Storage is the name of the storage system the job will use, may be empty.
 	Storage string
+	// Current Height
+	CurrentHeight int
 }
 
 type LilyWatchConfig struct {

--- a/lens/lily/api.go
+++ b/lens/lily/api.go
@@ -90,8 +90,6 @@ type LilyJobConfig struct {
 	RestartDelay time.Duration
 	// Storage is the name of the storage system the job will use, may be empty.
 	Storage string
-	// Current Height
-	CurrentHeight int
 }
 
 type LilyWatchConfig struct {

--- a/schedule/scheduler.go
+++ b/schedule/scheduler.go
@@ -84,10 +84,10 @@ type JobConfig struct {
 
 type Reporter struct {
 	// Current Height is the current height of the job
-	CurrentHeight int
+	CurrentHeight int64
 }
 
-func (r *Reporter) UpdateCurrentHeight(height int) {
+func (r *Reporter) UpdateCurrentHeight(height int64) {
 	r.CurrentHeight = height
 }
 

--- a/schedule/scheduler.go
+++ b/schedule/scheduler.go
@@ -82,6 +82,10 @@ type JobConfig struct {
 	EndedAt time.Time
 }
 
+func (j *JobConfig) UpdateCurrentHeight(height int) {
+	j.CurrentHeight = height
+}
+
 // Locker represents a general lock that a job may need to take before operating.
 type Locker interface {
 	Lock(context.Context) error

--- a/schedule/scheduler.go
+++ b/schedule/scheduler.go
@@ -91,10 +91,6 @@ func (r *Reporter) UpdateCurrentHeight(height int64) {
 	r.CurrentHeight = height
 }
 
-func (r *Reporter) GetStatus() Reporter {
-	return *r
-}
-
 // Locker represents a general lock that a job may need to take before operating.
 type Locker interface {
 	Lock(context.Context) error
@@ -364,7 +360,7 @@ type JobListResult struct {
 	StartedAt time.Time
 	EndedAt   time.Time
 
-	Report Reporter
+	Report *Reporter
 }
 
 var InvalidJobID = JobID(0)
@@ -394,9 +390,7 @@ func (s *Scheduler) Jobs() []JobListResult {
 			Params:              j.Params,
 			StartedAt:           j.StartedAt,
 			EndedAt:             j.EndedAt,
-		}
-		if j.Reporter != nil {
-			result.Report = j.Reporter.GetStatus()
+			Report:              j.Reporter,
 		}
 		out = append(out, result)
 		j.lk.Unlock()

--- a/schedule/scheduler.go
+++ b/schedule/scheduler.go
@@ -40,6 +40,9 @@ type JobConfig struct {
 	// running is true if the job is executing, false otherwise.
 	running bool
 
+	// current height
+	CurrentHeight int
+
 	// errorMsg will contain a (helpful) string iff a jobs execution has halted due to an error.
 	errorMsg string
 
@@ -347,6 +350,8 @@ type JobListResult struct {
 	Params    map[string]string
 	StartedAt time.Time
 	EndedAt   time.Time
+
+	CurrentHeight int
 }
 
 var InvalidJobID = JobID(0)
@@ -376,6 +381,7 @@ func (s *Scheduler) Jobs() []JobListResult {
 			Params:              j.Params,
 			StartedAt:           j.StartedAt,
 			EndedAt:             j.EndedAt,
+			CurrentHeight:       j.CurrentHeight,
 		})
 		j.lk.Unlock()
 	}


### PR DESCRIPTION
## Issue https://github.com/filecoin-project/lily/issues/788
### Description
The json returned by lily job list should include current height for walk, watch and gapfill jobs.
### Approach
Add the `currentHeight` in `Reporter`, then pass the `Reporter` to Watcher, Walker and Filler. Therefore, they can update the `currentHeight` during job execution. Finally, we could see the current height for walk, watch and gapfill jobs.