### PR TITLE
hotfix: Prevent from saving the empty string as jsonb type

### DIFF
--- a/tasks/messageexecutions/vm/task.go
+++ b/tasks/messageexecutions/vm/task.go
@@ -167,7 +167,9 @@ func (t *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 					})
 				} else {
 					// add the message params
-					vmMsg.Params = params
+					if params != "" {
+						vmMsg.Params = params
+					}
 				}
 
 				ret, _, err := util.ParseVmMessageReturn(child.Receipt.Return, child.Receipt.ReturnCodec, child.Message.Method, toCode)
@@ -180,7 +182,9 @@ func (t *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 					})
 				} else {
 					// add the message return.
-					vmMsg.Returns = ret
+					if ret != "" {
+						vmMsg.Returns = ret
+					}
 				}
 			}
 


### PR DESCRIPTION
## Description
Meet the issue
```
persist result (vm_messages.model.PersistableList): persisting model.PersistableList: persisting model: ERROR #22P02 invalid input syntax for type json
```
at epoch: `2683598`. We will get the issue during inserting the empty string `params`, `returns` as `jsonb` type in PostgreSQL.