### PR TITLE
fix: Fix the error jsonp format in vm_message

### DIFF
--- a/lens/util/repo.go
+++ b/lens/util/repo.go
@@ -36,7 +36,7 @@ func init() {
 var log = logging.Logger("lily/lens")
 
 type CBORByteArray struct {
-	params string
+	Params string
 }
 
 func ParseVmMessageParams(params []byte, paramsCodec uint64, method abi.MethodNum, actCode cid.Cid) (string, string, error) {
@@ -56,7 +56,7 @@ func ParseVmMessageParams(params []byte, paramsCodec uint64, method abi.MethodNu
 	// If the codec is 0, the parameters/return value are "empty".
 	// If the codec is 0x55, it's bytes.
 	if paramsCodec == 0 || paramsCodec == 0x55 {
-		paramj, err := json.Marshal(CBORByteArray{params: string(params)})
+		paramj, err := json.Marshal(CBORByteArray{Params: string(params)})
 		if err != nil {
 			return "", "", err
 		}
@@ -82,7 +82,7 @@ func ParseVmMessageReturn(ret []byte, retCodec uint64, method abi.MethodNum, act
 	// If the codec is 0, the parameters/return value are "empty".
 	// If the codec is 0x55, it's bytes.
 	if retCodec == 0 || retCodec == 0x55 {
-		retj, err := json.Marshal(CBORByteArray{params: string(ret)})
+		retj, err := json.Marshal(CBORByteArray{Params: string(ret)})
 		if err != nil {
 			return "", "", err
 		}

--- a/lens/util/repo.go
+++ b/lens/util/repo.go
@@ -35,6 +35,10 @@ func init() {
 
 var log = logging.Logger("lily/lens")
 
+type CBORByteArray struct {
+	params string
+}
+
 func ParseVmMessageParams(params []byte, paramsCodec uint64, method abi.MethodNum, actCode cid.Cid) (string, string, error) {
 	m, found := ActorRegistry.Methods[actCode][method]
 	if !found {
@@ -52,7 +56,11 @@ func ParseVmMessageParams(params []byte, paramsCodec uint64, method abi.MethodNu
 	// If the codec is 0, the parameters/return value are "empty".
 	// If the codec is 0x55, it's bytes.
 	if paramsCodec == 0 || paramsCodec == 0x55 {
-		return string(params), m.Name, nil
+		paramj, err := json.Marshal(CBORByteArray{params: string(params)})
+		if err != nil {
+			return "", "", err
+		}
+		return string(paramj), m.Name, nil
 	}
 	return ParseParams(params, method, actCode)
 }
@@ -74,7 +82,11 @@ func ParseVmMessageReturn(ret []byte, retCodec uint64, method abi.MethodNum, act
 	// If the codec is 0, the parameters/return value are "empty".
 	// If the codec is 0x55, it's bytes.
 	if retCodec == 0 || retCodec == 0x55 {
-		return string(ret), m.Name, nil
+		retj, err := json.Marshal(CBORByteArray{params: string(ret)})
+		if err != nil {
+			return "", "", err
+		}
+		return string(retj), m.Name, nil
 	}
 	return ParseReturn(ret, method, actCode)
 }


### PR DESCRIPTION
## Description
```
persist result (vm_messages.model.PersistableList): persisting model.PersistableList:
persisting model: ERROR #22P02 invalid input syntax for type json
```
at epoch: 2683598. We will get the issue during inserting the empty string params, returns as jsonb type in PostgreSQL.