### PR TITLE
fix: log unknown actor type without returning error

### DIFF
--- a/lens/util/repo.go
+++ b/lens/util/repo.go
@@ -185,7 +185,8 @@ func MethodAndParamsForMessage(m *types.Message, destCode cid.Cid) (string, stri
 
 	params, method, err := ParseParams(m.Params, m.Method, destCode)
 	if method == "Unknown" {
-		return "", "", fmt.Errorf("unknown method for actor type %s: %d", destCode.String(), int64(m.Method))
+		log.Errorf("unknown method for actor type %s: %d", destCode.String(), int64(m.Method))
+		return "", "", nil
 	}
 	if err != nil {
 		log.Warnf("failed to parse parameters of message %s: %v", m.Cid().String(), err)

--- a/lens/util/repo.go
+++ b/lens/util/repo.go
@@ -104,7 +104,7 @@ func ParseParams(params []byte, method abi.MethodNum, actCode cid.Cid) (_ string
 		}
 		err = fmt.Errorf("unknown method %d for actorCode %s name %s", method, actCode, builtin.ActorNameByCode(actCode))
 		log.Warnw("parsing vm message params", "error", err)
-		return string(paramj), "Unknown", nil
+		return string(paramj), method.String(), nil
 	}
 
 	// if the actor method doesn't expect params don't parse them
@@ -185,8 +185,7 @@ func MethodAndParamsForMessage(m *types.Message, destCode cid.Cid) (string, stri
 
 	params, method, err := ParseParams(m.Params, m.Method, destCode)
 	if method == "Unknown" {
-		log.Errorf("unknown method for actor type %s: %d", destCode.String(), int64(m.Method))
-		return "", "", nil
+		return "", "", fmt.Errorf("unknown method for actor type %s: %d", destCode.String(), int64(m.Method))
 	}
 	if err != nil {
 		log.Warnf("failed to parse parameters of message %s: %v", m.Cid().String(), err)

--- a/tasks/messages/message_test.go
+++ b/tasks/messages/message_test.go
@@ -47,7 +47,7 @@ func TestParseMessageParams(t *testing.T) {
 			actorCode:   cid.Undef,
 			wantMethod:  "Unknown",
 			wantEncoded: "",
-			wantErr:     true,
+			wantErr:     false,
 		},
 		{
 			// Derived from message bafy2bzaceah56ky4mny2qv3eg4zzjr7xxlht2bvxvcz6oozpe7k5ytjjhpezc

--- a/tasks/messages/message_test.go
+++ b/tasks/messages/message_test.go
@@ -106,8 +106,8 @@ func TestParseMessageParams(t *testing.T) {
 			method:      16,
 			params:      nil,
 			actorCode:   builtin3.AccountActorCodeID,
-			wantMethod:  "",
-			wantEncoded: "",
+			wantMethod:  "16",
+			wantEncoded: "null",
 			wantErr:     false,
 		},
 		{

--- a/tasks/messages/message_test.go
+++ b/tasks/messages/message_test.go
@@ -47,7 +47,7 @@ func TestParseMessageParams(t *testing.T) {
 			actorCode:   cid.Undef,
 			wantMethod:  "Unknown",
 			wantEncoded: "",
-			wantErr:     false,
+			wantErr:     true,
 		},
 		{
 			// Derived from message bafy2bzaceah56ky4mny2qv3eg4zzjr7xxlht2bvxvcz6oozpe7k5ytjjhpezc
@@ -108,7 +108,7 @@ func TestParseMessageParams(t *testing.T) {
 			actorCode:   builtin3.AccountActorCodeID,
 			wantMethod:  "",
 			wantEncoded: "",
-			wantErr:     true,
+			wantErr:     false,
 		},
 		{
 			// Derived from message bafy2bzacebpiuu7tgya6yz56sfllpqc3rqbo5s5xl7353xeuavc53qlpb4sqw


### PR DESCRIPTION
Don't error on unknown method numbers for FEVM.

Due to the [previous fix](https://github.com/filecoin-project/lily/pull/1165/files), it will return the `Unknown` method, then cause the error in `parsed_message`.  Therefore, we can use the same logic as `vm_message`: logging the error without returning error.