### PR TITLE
feat: Add the state and code_cid for actors table

### DIFF
--- a/model/actors/common/actors.go
+++ b/model/actors/common/actors.go
@@ -29,6 +29,8 @@ type Actor struct {
 	Balance string `pg:",notnull"`
 	// The next Actor nonce that is expected to appear on chain.
 	Nonce uint64 `pg:",use_zero"`
+	// Top level of state data as json.
+	State string `pg:",type:jsonb"`
 }
 
 func (a *Actor) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {

--- a/model/actors/common/actors.go
+++ b/model/actors/common/actors.go
@@ -23,6 +23,8 @@ type Actor struct {
 	StateRoot string `pg:",pk,notnull"`
 	// Human-readable identifier for the type of the actor.
 	Code string `pg:",notnull"`
+	// CID identifier for the type of the actor.
+	CodeCID string `pg:",notnull"`
 	// CID of the root of the state tree for the actor.
 	Head string `pg:",notnull"`
 	// Balance of Actor in attoFIL.

--- a/schemas/v1/20_actor_add_state.go
+++ b/schemas/v1/20_actor_add_state.go
@@ -7,7 +7,11 @@ func init() {
 ALTER TABLE {{ .SchemaName | default "public"}}.actors
     ADD COLUMN IF NOT EXISTS "state" jsonb;
 
+ALTER TABLE {{ .SchemaName | default "public"}}.actors
+	ADD COLUMN IF NOT EXISTS "code_cid" text;
+
 COMMENT ON COLUMN {{ .SchemaName | default "public"}}.actors.state IS 'Top level of state data.';
+COMMENT ON COLUMN {{ .SchemaName | default "public"}}.actors.code_cid IS 'CID identifier for the type of the actor.';
 `,
 	)
 }

--- a/schemas/v1/20_actor_add_state.go
+++ b/schemas/v1/20_actor_add_state.go
@@ -1,0 +1,13 @@
+package v1
+
+func init() {
+	patches.Register(
+		20,
+		`
+ALTER TABLE {{ .SchemaName | default "public"}}.actors
+    ADD COLUMN IF NOT EXISTS "state" jsonb;
+
+COMMENT ON COLUMN {{ .SchemaName | default "public"}}.actors.state IS 'Top level of state data.';
+`,
+	)
+}

--- a/schemas/v1/21_actor_add_state.go
+++ b/schemas/v1/21_actor_add_state.go
@@ -2,7 +2,7 @@ package v1
 
 func init() {
 	patches.Register(
-		20,
+		21,
 		`
 ALTER TABLE {{ .SchemaName | default "public"}}.actors
     ADD COLUMN IF NOT EXISTS "state" jsonb;

--- a/tasks/actorstate/raw/actor.go
+++ b/tasks/actorstate/raw/actor.go
@@ -61,5 +61,6 @@ func (RawActorExtractor) Extract(ctx context.Context, a actorstate.ActorInfo, no
 		Balance:   a.Actor.Balance.String(),
 		Nonce:     a.Actor.Nonce,
 		State:     stateStr,
+		CodeCID:   a.Actor.Code.String(),
 	}, nil
 }


### PR DESCRIPTION
## Description

Based on the information provided, it appears that the `actor_states` table is being deprecated because the data it contains is mostly covered by the `actors` table. However, there are two columns: `state` and` code_cid`, which are present in `actor_states` but missing in `actors`. To address this, these two columns will be added to the `actors` table, thereby making the `actor_states` table redundant. Once this is done, the `actor_states` table can be safely deprecated.