### PR TITLE
fix: batch insert actor & actor_state data

### DIFF
--- a/chain/indexer/integrated/processor/state.go
+++ b/chain/indexer/integrated/processor/state.go
@@ -584,12 +584,12 @@ func MakeProcessors(api tasks.DataSource, indexerTasks []string) (*IndexerProces
 			rae := &actorstate.RawActorExtractorMap{}
 			rae.Register(&rawtask.RawActorExtractor{})
 			rat := &rawtask.RawActorExtractor{}
-			out.ActorProcessors[t] = actorstate.NewTask2(api, rae, rat)
+			out.ActorProcessors[t] = actorstate.NewTaskWithTransformer(api, rae, rat)
 		case tasktype.ActorState:
 			rae := &actorstate.RawActorExtractorMap{}
 			rae.Register(&rawtask.RawActorStateExtractor{})
 			rat := &rawtask.RawActorStateExtractor{}
-			out.ActorProcessors[t] = actorstate.NewTask2(api, rae, rat)
+			out.ActorProcessors[t] = actorstate.NewTaskWithTransformer(api, rae, rat)
 
 			//
 			// Messages

--- a/chain/indexer/integrated/processor/state.go
+++ b/chain/indexer/integrated/processor/state.go
@@ -583,11 +583,13 @@ func MakeProcessors(api tasks.DataSource, indexerTasks []string) (*IndexerProces
 		case tasktype.Actor:
 			rae := &actorstate.RawActorExtractorMap{}
 			rae.Register(&rawtask.RawActorExtractor{})
-			out.ActorProcessors[t] = actorstate.NewTask(api, rae)
+			rat := &rawtask.RawActorExtractor{}
+			out.ActorProcessors[t] = actorstate.NewTask2(api, rae, rat)
 		case tasktype.ActorState:
 			rae := &actorstate.RawActorExtractorMap{}
 			rae.Register(&rawtask.RawActorStateExtractor{})
-			out.ActorProcessors[t] = actorstate.NewTask(api, rae)
+			rat := &rawtask.RawActorStateExtractor{}
+			out.ActorProcessors[t] = actorstate.NewTask2(api, rae, rat)
 
 			//
 			// Messages

--- a/chain/indexer/integrated/processor/state_internal_test.go
+++ b/chain/indexer/integrated/processor/state_internal_test.go
@@ -154,9 +154,9 @@ func TestNewProcessor(t *testing.T) {
 	rae := &actorstate.RawActorExtractorMap{}
 	rae.Register(&rawtask.RawActorExtractor{})
 	rat := &rawtask.RawActorExtractor{}
-	require.Equal(t, actorstate.NewTask2(nil, rae, rat), proc.actorProcessors[tasktype.Actor])
+	require.Equal(t, actorstate.NewTaskWithTransformer(nil, rae, rat), proc.actorProcessors[tasktype.Actor])
 	rae1 := &actorstate.RawActorExtractorMap{}
 	rae1.Register(&rawtask.RawActorStateExtractor{})
 	rat1 := &rawtask.RawActorStateExtractor{}
-	require.Equal(t, actorstate.NewTask2(nil, rae1, rat1), proc.actorProcessors[tasktype.ActorState])
+	require.Equal(t, actorstate.NewTaskWithTransformer(nil, rae1, rat1), proc.actorProcessors[tasktype.ActorState])
 }

--- a/chain/indexer/integrated/processor/state_internal_test.go
+++ b/chain/indexer/integrated/processor/state_internal_test.go
@@ -153,8 +153,10 @@ func TestNewProcessor(t *testing.T) {
 
 	rae := &actorstate.RawActorExtractorMap{}
 	rae.Register(&rawtask.RawActorExtractor{})
-	require.Equal(t, actorstate.NewTask(nil, rae), proc.actorProcessors[tasktype.Actor])
+	rat := &rawtask.RawActorExtractor{}
+	require.Equal(t, actorstate.NewTask2(nil, rae, rat), proc.actorProcessors[tasktype.Actor])
 	rae1 := &actorstate.RawActorExtractorMap{}
 	rae1.Register(&rawtask.RawActorStateExtractor{})
-	require.Equal(t, actorstate.NewTask(nil, rae1), proc.actorProcessors[tasktype.ActorState])
+	rat1 := &rawtask.RawActorStateExtractor{}
+	require.Equal(t, actorstate.NewTask2(nil, rae1, rat1), proc.actorProcessors[tasktype.ActorState])
 }

--- a/chain/indexer/integrated/processor/state_test.go
+++ b/chain/indexer/integrated/processor/state_test.go
@@ -312,7 +312,7 @@ func TestMakeProcessorsActors(t *testing.T) {
 			rae.Register(&rawtask.RawActorExtractor{})
 			require.Len(t, proc.ActorProcessors, 1)
 			rat := &rawtask.RawActorExtractor{}
-			require.Equal(t, actorstate.NewTask2(nil, rae, rat), proc.ActorProcessors[tasktype.Actor])
+			require.Equal(t, actorstate.NewTaskWithTransformer(nil, rae, rat), proc.ActorProcessors[tasktype.Actor])
 
 		})
 
@@ -323,7 +323,7 @@ func TestMakeProcessorsActors(t *testing.T) {
 			rae.Register(&rawtask.RawActorStateExtractor{})
 			require.Len(t, proc.ActorProcessors, 1)
 			rat := &rawtask.RawActorStateExtractor{}
-			require.Equal(t, actorstate.NewTask2(nil, rae, rat), proc.ActorProcessors[tasktype.ActorState])
+			require.Equal(t, actorstate.NewTaskWithTransformer(nil, rae, rat), proc.ActorProcessors[tasktype.ActorState])
 		})
 	})
 }

--- a/chain/indexer/integrated/processor/state_test.go
+++ b/chain/indexer/integrated/processor/state_test.go
@@ -311,7 +311,8 @@ func TestMakeProcessorsActors(t *testing.T) {
 			rae := &actorstate.RawActorExtractorMap{}
 			rae.Register(&rawtask.RawActorExtractor{})
 			require.Len(t, proc.ActorProcessors, 1)
-			require.Equal(t, actorstate.NewTask(nil, rae), proc.ActorProcessors[tasktype.Actor])
+			rat := &rawtask.RawActorExtractor{}
+			require.Equal(t, actorstate.NewTask2(nil, rae, rat), proc.ActorProcessors[tasktype.Actor])
 
 		})
 
@@ -321,7 +322,8 @@ func TestMakeProcessorsActors(t *testing.T) {
 			rae := &actorstate.RawActorExtractorMap{}
 			rae.Register(&rawtask.RawActorStateExtractor{})
 			require.Len(t, proc.ActorProcessors, 1)
-			require.Equal(t, actorstate.NewTask(nil, rae), proc.ActorProcessors[tasktype.ActorState])
+			rat := &rawtask.RawActorStateExtractor{}
+			require.Equal(t, actorstate.NewTask2(nil, rae, rat), proc.ActorProcessors[tasktype.ActorState])
 		})
 	})
 }

--- a/tasks/actorstate/raw/actor.go
+++ b/tasks/actorstate/raw/actor.go
@@ -3,6 +3,7 @@ package raw
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	logging "github.com/ipfs/go-log/v2"
 	"go.opentelemetry.io/otel"
@@ -63,4 +64,16 @@ func (RawActorExtractor) Extract(ctx context.Context, a actorstate.ActorInfo, no
 		State:     stateStr,
 		CodeCID:   a.Actor.Code.String(),
 	}, nil
+}
+
+func (RawActorExtractor) Transform(ctx context.Context, data model.PersistableList) (model.PersistableList, error) {
+	actorList := make(commonmodel.ActorList, 0, len(data))
+	for _, d := range data {
+		a, ok := d.(*commonmodel.Actor)
+		if !ok {
+			return nil, fmt.Errorf("expected Actor type but got: %T", d)
+		}
+		actorList = append(actorList, a)
+	}
+	return model.PersistableList{actorList}, nil
 }

--- a/tasks/actorstate/raw/actor_state.go
+++ b/tasks/actorstate/raw/actor_state.go
@@ -3,6 +3,7 @@ package raw
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
@@ -44,4 +45,16 @@ func (RawActorStateExtractor) Extract(ctx context.Context, a actorstate.ActorInf
 		Code:   a.Actor.Code.String(),
 		State:  string(state),
 	}, nil
+}
+
+func (RawActorStateExtractor) Transform(ctx context.Context, data model.PersistableList) (model.PersistableList, error) {
+	actorStateList := make(commonmodel.ActorStateList, 0, len(data))
+	for _, d := range data {
+		a, ok := d.(*commonmodel.ActorState)
+		if !ok {
+			return nil, fmt.Errorf("expected Actor type but got: %T", d)
+		}
+		actorStateList = append(actorStateList, a)
+	}
+	return model.PersistableList{actorStateList}, nil
 }

--- a/tasks/actorstate/raw/actor_state.go
+++ b/tasks/actorstate/raw/actor_state.go
@@ -52,7 +52,7 @@ func (RawActorStateExtractor) Transform(ctx context.Context, data model.Persista
 	for _, d := range data {
 		a, ok := d.(*commonmodel.ActorState)
 		if !ok {
-			return nil, fmt.Errorf("expected Actor type but got: %T", d)
+			return nil, fmt.Errorf("expected ActorState type but got: %T", d)
 		}
 		actorStateList = append(actorStateList, a)
 	}

--- a/tasks/actorstate/task.go
+++ b/tasks/actorstate/task.go
@@ -33,7 +33,7 @@ func NewTask(node tasks.DataSource, extractorMap ActorExtractorMap) *Task {
 	}
 }
 
-func NewTask2(node tasks.DataSource, extractorMap ActorExtractorMap, dataTransformer ActorDataTransformer) *Task {
+func NewTaskWithTransformer(node tasks.DataSource, extractorMap ActorExtractorMap, dataTransformer ActorDataTransformer) *Task {
 	return &Task{
 		node:            node,
 		extractorMap:    extractorMap,


### PR DESCRIPTION
Currently, actor state changes are stored as `model.PersistableList`, which doesn't support batch persistence. This PR adds  a transformer to actorstate task to convert `model.PersistableList` to corresponding model type that supports batch persistence.
This resolves #1190.