### PR TITLE
chore: move persist duration timer to ExportResult

### DIFF
--- a/chain/indexer/exporter.go
+++ b/chain/indexer/exporter.go
@@ -63,6 +63,8 @@ func (me *ModelExporter) ExportResult(ctx context.Context, strg model.Storage, h
 			defer span.End()
 			start := time.Now()
 			ctx, _ = tag.New(ctx, tag.Upsert(metrics.TaskType, res.Name))
+			stop := metrics.Timer(ctx, metrics.PersistDuration)
+			defer stop()
 
 			if err := strg.PersistBatch(ctx, res.Model); err != nil {
 				stats.Record(ctx, metrics.PersistFailure.M(1))

--- a/model/actors/common/actors.go
+++ b/model/actors/common/actors.go
@@ -46,8 +46,6 @@ func (a *Actor) Persist(ctx context.Context, s model.StorageBatch, version model
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "actors"))
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	return s.PersistModel(ctx, a)
 }
@@ -64,8 +62,6 @@ func (actors ActorList) Persist(ctx context.Context, s model.StorageBatch, versi
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "actors"))
 	metrics.RecordCount(ctx, metrics.PersistModel, len(actors))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	if len(actors) == 0 {
 		return nil
@@ -95,9 +91,6 @@ func (as *ActorState) Persist(ctx context.Context, s model.StorageBatch, version
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "actor_states"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, as)
 }
@@ -113,8 +106,6 @@ func (states ActorStateList) Persist(ctx context.Context, s model.StorageBatch, 
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "actor_states"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	if len(states) == 0 {
 		return nil
@@ -143,17 +134,12 @@ func (a *ActorCode) Persist(ctx context.Context, s model.StorageBatch, version m
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "actor_codes"))
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	return s.PersistModel(ctx, a)
 }
 
 func (acl ActorCodeList) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "actor_codes"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, len(acl))
 	return s.PersistModel(ctx, acl)
 }
@@ -177,17 +163,12 @@ func (a *ActorMethod) Persist(ctx context.Context, s model.StorageBatch, version
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "actor_methods"))
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	return s.PersistModel(ctx, a)
 }
 
 func (acl ActorMethodList) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "actor_methods"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, len(acl))
 	return s.PersistModel(ctx, acl)
 }

--- a/model/actors/datacap/state.go
+++ b/model/actors/datacap/state.go
@@ -26,8 +26,6 @@ type DataCapBalance struct {
 
 func (d *DataCapBalance) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "data_cap_balances"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	return s.PersistModel(ctx, d)
 }
@@ -36,8 +34,6 @@ type DataCapBalanceList []*DataCapBalance
 
 func (d DataCapBalanceList) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "data_cap_balances"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	if len(d) == 0 {
 		return nil

--- a/model/actors/init/idaddress.go
+++ b/model/actors/init/idaddress.go
@@ -53,8 +53,6 @@ func (ia *IDAddress) AsVersion(version model.Version) (interface{}, bool) {
 
 func (ia *IDAddress) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "id_addresses"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	m, ok := ia.AsVersion(version)
 	if !ok {
@@ -75,8 +73,6 @@ func (ias IDAddressList) Persist(ctx context.Context, s model.StorageBatch, vers
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "id_addresses"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	if version.Major != 1 {
 		// Support older versions, but in a non-optimal way

--- a/model/actors/market/dealproposal.go
+++ b/model/actors/market/dealproposal.go
@@ -55,9 +55,6 @@ type MarketDealProposal struct {
 
 func (dp *MarketDealProposal) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "market_deal_proposals"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, dp)
 }
@@ -72,9 +69,6 @@ func (dps MarketDealProposals) Persist(ctx context.Context, s model.StorageBatch
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "market_deal_proposals"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, len(dps))
 	return s.PersistModel(ctx, dps)
 }

--- a/model/actors/market/dealstate.go
+++ b/model/actors/market/dealstate.go
@@ -22,9 +22,6 @@ type MarketDealState struct {
 
 func (ds *MarketDealState) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "market_deal_states"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, ds)
 }
@@ -39,9 +36,6 @@ func (dss MarketDealStates) Persist(ctx context.Context, s model.StorageBatch, v
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "market_deal_states"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, len(dss))
 	return s.PersistModel(ctx, dss)
 }

--- a/model/actors/miner/beneficiary.go
+++ b/model/actors/miner/beneficiary.go
@@ -33,9 +33,6 @@ func (m *MinerBeneficiary) Persist(ctx context.Context, s model.StorageBatch, ve
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_beneficiaries"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, m)
 }
@@ -47,8 +44,6 @@ func (ml MinerBeneficiaryList) Persist(ctx context.Context, s model.StorageBatch
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_beneficiaries"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	if len(ml) == 0 {
 		return nil

--- a/model/actors/miner/currentdeadline.go
+++ b/model/actors/miner/currentdeadline.go
@@ -28,9 +28,6 @@ func (m *MinerCurrentDeadlineInfo) Persist(ctx context.Context, s model.StorageB
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_current_deadline_infos"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, m)
 }
@@ -42,8 +39,6 @@ func (ml MinerCurrentDeadlineInfoList) Persist(ctx context.Context, s model.Stor
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_current_deadline_infos"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	if len(ml) == 0 {
 		return nil

--- a/model/actors/miner/feedebt.go
+++ b/model/actors/miner/feedebt.go
@@ -53,8 +53,6 @@ func (m *MinerFeeDebt) Persist(ctx context.Context, s model.StorageBatch, versio
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_fee_debts"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	vm, ok := m.AsVersion(version)
 	if !ok {
@@ -72,8 +70,6 @@ func (ml MinerFeeDebtList) Persist(ctx context.Context, s model.StorageBatch, ve
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_fee_debts"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	if len(ml) == 0 {
 		return nil

--- a/model/actors/miner/lockedfunds.go
+++ b/model/actors/miner/lockedfunds.go
@@ -59,8 +59,6 @@ func (m *MinerLockedFund) Persist(ctx context.Context, s model.StorageBatch, ver
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_locked_funds"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	vm, ok := m.AsVersion(version)
 	if !ok {
@@ -78,8 +76,6 @@ func (ml MinerLockedFundsList) Persist(ctx context.Context, s model.StorageBatch
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_locked_funds"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	if len(ml) == 0 {
 		return nil

--- a/model/actors/miner/minerinfo.go
+++ b/model/actors/miner/minerinfo.go
@@ -35,9 +35,6 @@ func (m *MinerInfo) Persist(ctx context.Context, s model.StorageBatch, version m
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_infos"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, m)
 }
@@ -49,8 +46,6 @@ func (ml MinerInfoList) Persist(ctx context.Context, s model.StorageBatch, versi
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_infos"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	if len(ml) == 0 {
 		return nil

--- a/model/actors/miner/precommit.go
+++ b/model/actors/miner/precommit.go
@@ -89,8 +89,6 @@ func (mpi *MinerPreCommitInfo) AsVersion(version model.Version) (interface{}, bo
 
 func (mpi *MinerPreCommitInfo) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_pre_commit_infos"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	m, ok := mpi.AsVersion(version)
 	if !ok {
@@ -111,8 +109,6 @@ func (ml MinerPreCommitInfoList) Persist(ctx context.Context, s model.StorageBat
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_pre_commit_infos"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	if len(ml) == 0 {
 		return nil

--- a/model/actors/miner/precommitV9.go
+++ b/model/actors/miner/precommitV9.go
@@ -43,8 +43,6 @@ func (mpi *MinerPreCommitInfoV9) AsVersion(version model.Version) (interface{}, 
 
 func (mpi *MinerPreCommitInfoV9) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_pre_commit_infos"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	m, ok := mpi.AsVersion(version)
 	if !ok {
@@ -65,8 +63,6 @@ func (ml MinerPreCommitInfoV9List) Persist(ctx context.Context, s model.StorageB
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_pre_commit_infos"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	if len(ml) == 0 {
 		return nil

--- a/model/actors/miner/sector.go
+++ b/model/actors/miner/sector.go
@@ -110,8 +110,6 @@ func (msi *MinerSectorInfoV7) AsVersion(version model.Version) (interface{}, boo
 
 func (msi *MinerSectorInfoV7) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_sector_infos_v7"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	m, ok := msi.AsVersion(version)
 	if !ok {
@@ -134,8 +132,6 @@ func (ml MinerSectorInfoV7List) Persist(ctx context.Context, s model.StorageBatc
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_sector_infos_v7"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	if len(ml) == 0 {
 		return nil
@@ -185,8 +181,6 @@ func (msi *MinerSectorInfoV1_6) AsVersion(version model.Version) (interface{}, b
 
 func (msi *MinerSectorInfoV1_6) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_sector_infos"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	m, ok := msi.AsVersion(version)
 	if !ok {
@@ -207,8 +201,6 @@ func (ml MinerSectorInfoV1_6List) Persist(ctx context.Context, s model.StorageBa
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_sector_infos"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	if len(ml) == 0 {
 		return nil

--- a/model/actors/miner/sectordeals.go
+++ b/model/actors/miner/sectordeals.go
@@ -19,9 +19,6 @@ type MinerSectorDeal struct {
 
 func (ds *MinerSectorDeal) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_sector_deals"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, ds)
 }
@@ -36,8 +33,6 @@ func (ml MinerSectorDealList) Persist(ctx context.Context, s model.StorageBatch,
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_sector_deals"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	if len(ml) == 0 {
 		return nil

--- a/model/actors/miner/sectorevents.go
+++ b/model/actors/miner/sectorevents.go
@@ -41,9 +41,6 @@ type MinerSectorEvent struct {
 
 func (mse *MinerSectorEvent) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_sector_events"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, mse)
 }
@@ -58,8 +55,6 @@ func (l MinerSectorEventList) Persist(ctx context.Context, s model.StorageBatch,
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_sector_events"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	if len(l) == 0 {
 		return nil

--- a/model/actors/miner/sectorposts.go
+++ b/model/actors/miner/sectorposts.go
@@ -22,9 +22,6 @@ type MinerSectorPostList []*MinerSectorPost
 
 func (msp *MinerSectorPost) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_sector_posts"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, msp)
 }
@@ -40,9 +37,6 @@ func (ml MinerSectorPostList) Persist(ctx context.Context, s model.StorageBatch,
 	}
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "miner_sector_posts"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, len(ml))
 	return s.PersistModel(ctx, ml)
 }

--- a/model/actors/multisig/transactions.go
+++ b/model/actors/multisig/transactions.go
@@ -24,9 +24,6 @@ type MultisigTransaction struct {
 
 func (m *MultisigTransaction) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "multisig_transactions"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, m)
 }
@@ -35,9 +32,6 @@ type MultisigTransactionList []*MultisigTransaction
 
 func (ml MultisigTransactionList) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "multisig_transactions"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, len(ml))
 	return s.PersistModel(ctx, ml)
 }

--- a/model/actors/power/chainpower.go
+++ b/model/actors/power/chainpower.go
@@ -83,8 +83,6 @@ func (cp *ChainPower) Persist(ctx context.Context, s model.StorageBatch, version
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "chain_powers"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	vcp, ok := cp.AsVersion(version)
 	if !ok {
@@ -108,8 +106,6 @@ func (cpl ChainPowerList) Persist(ctx context.Context, s model.StorageBatch, ver
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "chain_powers"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	if len(cpl) == 0 {
 		return nil

--- a/model/actors/power/claimedpower.go
+++ b/model/actors/power/claimedpower.go
@@ -54,8 +54,6 @@ func (p *PowerActorClaim) Persist(ctx context.Context, s model.StorageBatch, ver
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "power_actor_claims"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	vp, ok := p.AsVersion(version)
 	if !ok {
@@ -73,8 +71,6 @@ func (pl PowerActorClaimList) Persist(ctx context.Context, s model.StorageBatch,
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "power_actor_claims"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	if len(pl) == 0 {
 		return nil

--- a/model/actors/reward/chainreward.go
+++ b/model/actors/reward/chainreward.go
@@ -73,8 +73,6 @@ func (r *ChainReward) Persist(ctx context.Context, s model.StorageBatch, version
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "chain_rewards"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	vr, ok := r.AsVersion(version)
 	if !ok {

--- a/model/actors/verifreg/claims.go
+++ b/model/actors/verifreg/claims.go
@@ -26,8 +26,6 @@ type VerifiedRegistryClaim struct {
 
 func (v *VerifiedRegistryClaim) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "verified_registry_claim"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	return s.PersistModel(ctx, v)
 }
@@ -39,8 +37,6 @@ func (v VerifiedRegistryClaimList) Persist(ctx context.Context, s model.StorageB
 		return nil
 	}
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "verified_registry_claim"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	return s.PersistModel(ctx, v)
 }

--- a/model/actors/verifreg/state.go
+++ b/model/actors/verifreg/state.go
@@ -25,8 +25,6 @@ type VerifiedRegistryVerifier struct {
 
 func (v *VerifiedRegistryVerifier) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "verified_registry_verifier"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	return s.PersistModel(ctx, v)
 }
@@ -35,8 +33,6 @@ type VerifiedRegistryVerifiersList []*VerifiedRegistryVerifier
 
 func (v VerifiedRegistryVerifiersList) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "verified_registry_verifier"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	return s.PersistModel(ctx, v)
 }
@@ -52,8 +48,6 @@ type VerifiedRegistryVerifiedClient struct {
 
 func (v *VerifiedRegistryVerifiedClient) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "verified_registry_verified_client"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	return s.PersistModel(ctx, v)
 }
@@ -62,8 +56,6 @@ type VerifiedRegistryVerifiedClientsList []*VerifiedRegistryVerifiedClient
 
 func (v VerifiedRegistryVerifiedClientsList) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "verified_registry_verified_client"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	return s.PersistModel(ctx, v)
 }

--- a/model/blocks/drand.go
+++ b/model/blocks/drand.go
@@ -34,9 +34,6 @@ type DrandBlockEntrie struct {
 
 func (dbe *DrandBlockEntrie) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "drand_block_entries"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, dbe)
 }
@@ -54,9 +51,6 @@ func (dbes DrandBlockEntries) Persist(ctx context.Context, s model.StorageBatch,
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "drand_block_entries"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, len(dbes))
 	return s.PersistModel(ctx, dbes)
 }

--- a/model/blocks/header.go
+++ b/model/blocks/header.go
@@ -40,9 +40,6 @@ func NewBlockHeader(bh *types.BlockHeader) *BlockHeader {
 
 func (bh *BlockHeader) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "block_headers"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, bh)
 }
@@ -60,9 +57,6 @@ func (bhl BlockHeaders) Persist(ctx context.Context, s model.StorageBatch, versi
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "block_headers"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, len(bhl))
 	return s.PersistModel(ctx, bhl)
 }

--- a/model/blocks/parent.go
+++ b/model/blocks/parent.go
@@ -19,9 +19,6 @@ type BlockParent struct {
 
 func (bp *BlockParent) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "block_parents"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, bp)
 }
@@ -51,9 +48,6 @@ func (bps BlockParents) Persist(ctx context.Context, s model.StorageBatch, versi
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "block_parents"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, len(bps))
 	return s.PersistModel(ctx, bps)
 }

--- a/model/chain/consensus.go
+++ b/model/chain/consensus.go
@@ -24,8 +24,6 @@ func (c ChainConsensus) Persist(ctx context.Context, s model.StorageBatch, versi
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "chain_consensus"))
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	return s.PersistModel(ctx, c)
 }
@@ -41,8 +39,6 @@ func (c ChainConsensusList) Persist(ctx context.Context, s model.StorageBatch, v
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "chain_consensus"))
 	metrics.RecordCount(ctx, metrics.PersistModel, len(c))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	if len(c) == 0 {
 		return nil

--- a/model/chain/economics.go
+++ b/model/chain/economics.go
@@ -58,8 +58,6 @@ func (c *ChainEconomics) AsVersion(version model.Version) (interface{}, bool) {
 
 func (c *ChainEconomics) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "chain_economics"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	m, ok := c.AsVersion(version)
 	if !ok {
@@ -83,8 +81,6 @@ func (l ChainEconomicsList) Persist(ctx context.Context, s model.StorageBatch, v
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "chain_economics"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	if version.Major != 1 {
 		// Support older versions, but in a non-optimal way

--- a/model/derived/gasoutputs.go
+++ b/model/derived/gasoutputs.go
@@ -108,8 +108,6 @@ func (g *GasOutputs) AsVersion(version model.Version) (interface{}, bool) {
 
 func (g *GasOutputs) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "derived_gas_outputs"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	vg, ok := g.AsVersion(version)
 	if !ok {
@@ -133,8 +131,6 @@ func (l GasOutputsList) Persist(ctx context.Context, s model.StorageBatch, versi
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "derived_gas_outputs"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	if version.Major != 1 {
 		vgl := make([]interface{}, 0, len(l))

--- a/model/fevm/fevmactorstats.go
+++ b/model/fevm/fevmactorstats.go
@@ -34,9 +34,6 @@ type FEVMActorStats struct {
 
 func (f *FEVMActorStats) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "fevm_actor_stats"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, f)
 }
@@ -48,9 +45,6 @@ func (f FEVMActorStatsList) Persist(ctx context.Context, s model.StorageBatch, v
 		return nil
 	}
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "fevm_actor_stats"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, len(f))
 	return s.PersistModel(ctx, f)
 }

--- a/model/messages/actorevent.go
+++ b/model/messages/actorevent.go
@@ -26,9 +26,6 @@ type ActorEvent struct {
 
 func (a *ActorEvent) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "actor_events"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, a)
 }
@@ -40,9 +37,6 @@ func (al ActorEventList) Persist(ctx context.Context, s model.StorageBatch, vers
 		return nil
 	}
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "actor_events"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, len(al))
 	return s.PersistModel(ctx, al)
 }

--- a/model/messages/blockmessage.go
+++ b/model/messages/blockmessage.go
@@ -18,9 +18,6 @@ type BlockMessage struct {
 
 func (bm *BlockMessage) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "block_messages"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, bm)
 }
@@ -38,9 +35,6 @@ func (bms BlockMessages) Persist(ctx context.Context, s model.StorageBatch, vers
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "block_messages"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, len(bms))
 	return s.PersistModel(ctx, bms)
 }

--- a/model/messages/gaseconomy.go
+++ b/model/messages/gaseconomy.go
@@ -69,8 +69,6 @@ func (g *MessageGasEconomy) AsVersion(version model.Version) (interface{}, bool)
 
 func (g *MessageGasEconomy) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "message_gas_economy"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	vm, ok := g.AsVersion(version)
 	if !ok {

--- a/model/messages/internal.go
+++ b/model/messages/internal.go
@@ -29,9 +29,6 @@ type InternalMessage struct {
 
 func (im *InternalMessage) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "internal_messages"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, im)
 }
@@ -49,9 +46,6 @@ func (l InternalMessageList) Persist(ctx context.Context, s model.StorageBatch, 
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "internal_messages"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, len(l))
 	return s.PersistModel(ctx, l)
 }
@@ -69,9 +63,6 @@ type InternalParsedMessage struct {
 
 func (ipm *InternalParsedMessage) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "internal_parsed_messages"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, ipm)
 }
@@ -89,9 +80,6 @@ func (l InternalParsedMessageList) Persist(ctx context.Context, s model.StorageB
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "internal_parsed_messages"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, len(l))
 	return s.PersistModel(ctx, l)
 }

--- a/model/messages/message.go
+++ b/model/messages/message.go
@@ -74,8 +74,6 @@ func (m *Message) AsVersion(version model.Version) (interface{}, bool) {
 
 func (m *Message) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "messages"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	vm, ok := m.AsVersion(version)
 	if !ok {
@@ -99,8 +97,6 @@ func (ms Messages) Persist(ctx context.Context, s model.StorageBatch, version mo
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "messages"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	if version.Major != 1 {
 		vms := make([]interface{}, 0, len(ms))

--- a/model/messages/messageparams.go
+++ b/model/messages/messageparams.go
@@ -17,8 +17,6 @@ type MessageParam struct {
 
 func (m *MessageParam) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "message_params"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, m)
@@ -31,8 +29,6 @@ func (ml MessageParamList) Persist(ctx context.Context, s model.StorageBatch, ve
 		return nil
 	}
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "message_params"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	metrics.RecordCount(ctx, metrics.PersistModel, len(ml))
 	return s.PersistModel(ctx, ml)

--- a/model/messages/parsedmessage.go
+++ b/model/messages/parsedmessage.go
@@ -58,8 +58,6 @@ func (pm *ParsedMessage) AsVersion(version model.Version) (interface{}, bool) {
 
 func (pm *ParsedMessage) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "parsed_messages"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	vpm, ok := pm.AsVersion(version)
 	if !ok {
@@ -83,8 +81,6 @@ func (pms ParsedMessages) Persist(ctx context.Context, s model.StorageBatch, ver
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "parsed_messages"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	if version.Major != 1 {
 		vpms := make([]interface{}, 0, len(pms))

--- a/model/messages/receipt.go
+++ b/model/messages/receipt.go
@@ -22,9 +22,6 @@ type Receipt struct {
 
 func (r *Receipt) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "receipts"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, r)
 }
@@ -42,9 +39,6 @@ func (rs Receipts) Persist(ctx context.Context, s model.StorageBatch, version mo
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "receipts"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, len(rs))
 	return s.PersistModel(ctx, rs)
 }

--- a/model/messages/receiptparams.go
+++ b/model/messages/receiptparams.go
@@ -17,9 +17,6 @@ type ReceiptReturn struct {
 
 func (m *ReceiptReturn) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "receipt_return"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, m)
 }
@@ -28,9 +25,6 @@ type ReceiptReturnList []*ReceiptReturn
 
 func (rl ReceiptReturnList) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "receipt_return"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, len(rl))
 	return s.PersistModel(ctx, rl)
 }

--- a/model/messages/vm.go
+++ b/model/messages/vm.go
@@ -45,9 +45,6 @@ type VMMessage struct {
 
 func (v *VMMessage) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "vm_messages"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, v)
 }
@@ -59,9 +56,6 @@ func (vl VMMessageList) Persist(ctx context.Context, s model.StorageBatch, versi
 		return nil
 	}
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "vm_messages"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, len(vl))
 	return s.PersistModel(ctx, vl)
 }

--- a/model/msapprovals/msapprovals.go
+++ b/model/msapprovals/msapprovals.go
@@ -28,9 +28,6 @@ type MultisigApproval struct {
 
 func (ma *MultisigApproval) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "multisig_approvals"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, ma)
 }
@@ -42,9 +39,6 @@ func (mal MultisigApprovalList) Persist(ctx context.Context, s model.StorageBatc
 		return nil
 	}
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "multisig_approvals"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, len(mal))
 	return s.PersistModel(ctx, mal)
 }

--- a/model/surveyed/minerprotocols.go
+++ b/model/surveyed/minerprotocols.go
@@ -33,8 +33,6 @@ type MinerProtocol struct {
 
 func (m *MinerProtocol) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "surveyed_miner_protocols"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	return s.PersistModel(ctx, m)
 }
@@ -52,8 +50,6 @@ func (m MinerProtocolList) Persist(ctx context.Context, s model.StorageBatch, ve
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "surveyed_miner_protocols"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	return s.PersistModel(ctx, m)
 }

--- a/model/surveyed/peeragent.go
+++ b/model/surveyed/peeragent.go
@@ -34,8 +34,6 @@ type PeerAgent struct {
 
 func (p *PeerAgent) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "surveyed_peer_agents"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	return s.PersistModel(ctx, p)
 }
@@ -53,8 +51,6 @@ func (l PeerAgentList) Persist(ctx context.Context, s model.StorageBatch, versio
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "surveyed_peer_agents"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	return s.PersistModel(ctx, l)
 }

--- a/model/visor/gapreport.go
+++ b/model/visor/gapreport.go
@@ -26,9 +26,6 @@ type GapReport struct {
 
 func (p *GapReport) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "visor_gap_reports"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, p)
 }
@@ -46,9 +43,6 @@ func (pl GapReportList) Persist(ctx context.Context, s model.StorageBatch, versi
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "visor_gap_reports"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, len(pl))
 	return s.PersistModel(ctx, pl)
 }

--- a/model/visor/processingreport.go
+++ b/model/visor/processingreport.go
@@ -47,8 +47,6 @@ type ProcessingReport struct {
 
 func (p *ProcessingReport) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "visor_processing_reports"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
 
 	metrics.RecordCount(ctx, metrics.PersistModel, 1)
 	return s.PersistModel(ctx, p)
@@ -67,9 +65,6 @@ func (pl ProcessingReportList) Persist(ctx context.Context, s model.StorageBatch
 	defer span.End()
 
 	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "visor_processing_reports"))
-	stop := metrics.Timer(ctx, metrics.PersistDuration)
-	defer stop()
-
 	metrics.RecordCount(ctx, metrics.PersistModel, len(pl))
 	return s.PersistModel(ctx, pl)
 }


### PR DESCRIPTION
Currently, persist duration metric represent the time it takes to persist one or many rows. This is not meaningful. We want to know the total time it takes to persist the whole table. 