### PR TITLE
fix: CodeCID should be at end of model

### DIFF
--- a/model/actors/common/actors.go
+++ b/model/actors/common/actors.go
@@ -23,8 +23,6 @@ type Actor struct {
 	StateRoot string `pg:",pk,notnull"`
 	// Human-readable identifier for the type of the actor.
 	Code string `pg:",notnull"`
-	// CID identifier for the type of the actor.
-	CodeCID string `pg:",notnull"`
 	// CID of the root of the state tree for the actor.
 	Head string `pg:",notnull"`
 	// Balance of Actor in attoFIL.
@@ -33,6 +31,8 @@ type Actor struct {
 	Nonce uint64 `pg:",use_zero"`
 	// Top level of state data as json.
 	State string `pg:",type:jsonb"`
+	// CID identifier for the type of the actor.
+	CodeCID string `pg:",notnull"`
 }
 
 func (a *Actor) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {


### PR DESCRIPTION
CSVs produced follow the order of the definition in the model. So CSVs of `actors` produced with this model definition are ordered like so:

```
height,id,state_root,code,code_cid,head,balance,nonce,state
```

This is problematic when inserting CSVs to other data sources as one then has to create these two columns before the change is introduced and fill these `null` values manually (really only a problem for `code_cid` which is in the middle of the table).

Note that Postgres doesn't have this issue (new columns are appended at the end).