### PR TITLE
feat: add new option for walk config

### DIFF
--- a/chain/walk/walker_test.go
+++ b/chain/walk/walker_test.go
@@ -56,7 +56,7 @@ func TestWalker(t *testing.T) {
 
 	t.Logf("initializing indexer")
 	reporter := &schedule.Reporter{}
-	idx := NewWalker(im, nodeAPI, t.Name(), []string{tasktype.BlocksTask}, 0, int64(head.Height()), reporter)
+	idx := NewWalker(im, nodeAPI, t.Name(), []string{tasktype.BlocksTask}, 0, int64(head.Height()), reporter, false)
 
 	t.Logf("indexing chain")
 	err = idx.WalkChain(ctx, nodeAPI, head)

--- a/commands/job/job.go
+++ b/commands/job/job.go
@@ -35,6 +35,7 @@ var JobRunCmd = &cli.Command{
 		RunRestartDelayFlag,
 		RunRestartFailure,
 		RunRestartCompletion,
+		StopOnFatalError,
 	},
 	Subcommands: []*cli.Command{
 		WalkCmd,

--- a/commands/job/job.go
+++ b/commands/job/job.go
@@ -35,7 +35,7 @@ var JobRunCmd = &cli.Command{
 		RunRestartDelayFlag,
 		RunRestartFailure,
 		RunRestartCompletion,
-		StopOnFatalError,
+		StopOnError,
 	},
 	Subcommands: []*cli.Command{
 		WalkCmd,

--- a/commands/job/options.go
+++ b/commands/job/options.go
@@ -21,6 +21,7 @@ type runOpts struct {
 
 	RestartCompletion bool
 	RestartFailure    bool
+	StopOnFatalError  bool
 }
 
 func (r runOpts) ParseJobConfig(kind string) lily.LilyJobConfig {
@@ -35,6 +36,7 @@ func (r runOpts) ParseJobConfig(kind string) lily.LilyJobConfig {
 		RestartOnFailure:    RunFlags.RestartFailure,
 		RestartOnCompletion: RunFlags.RestartCompletion,
 		RestartDelay:        RunFlags.RestartDelay,
+		StopOnFatalError:    RunFlags.StopOnFatalError,
 	}
 }
 
@@ -94,6 +96,14 @@ var RunRestartFailure = &cli.BoolFlag{
 	EnvVars:     []string{"LILY_JOB_RESTART_FAILURE"},
 	Value:       false,
 	Destination: &RunFlags.RestartFailure,
+}
+
+var StopOnFatalError = &cli.BoolFlag{
+	Name:        "stop-on-fatal-error",
+	Usage:       "Stop the job if it get error.",
+	EnvVars:     []string{"LILY_JOB_STOP_ON_FATAL_ERROR"},
+	Value:       false,
+	Destination: &RunFlags.StopOnFatalError,
 }
 
 type notifyOps struct {

--- a/commands/job/options.go
+++ b/commands/job/options.go
@@ -21,7 +21,7 @@ type runOpts struct {
 
 	RestartCompletion bool
 	RestartFailure    bool
-	StopOnFatalError  bool
+	StopOnError       bool
 }
 
 func (r runOpts) ParseJobConfig(kind string) lily.LilyJobConfig {
@@ -36,7 +36,7 @@ func (r runOpts) ParseJobConfig(kind string) lily.LilyJobConfig {
 		RestartOnFailure:    RunFlags.RestartFailure,
 		RestartOnCompletion: RunFlags.RestartCompletion,
 		RestartDelay:        RunFlags.RestartDelay,
-		StopOnFatalError:    RunFlags.StopOnFatalError,
+		StopOnError:         RunFlags.StopOnError,
 	}
 }
 
@@ -98,12 +98,12 @@ var RunRestartFailure = &cli.BoolFlag{
 	Destination: &RunFlags.RestartFailure,
 }
 
-var StopOnFatalError = &cli.BoolFlag{
-	Name:        "stop-on-fatal-error",
+var StopOnError = &cli.BoolFlag{
+	Name:        "stop-on-error",
 	Usage:       "Stop the job if it get error.",
-	EnvVars:     []string{"LILY_JOB_STOP_ON_FATAL_ERROR"},
+	EnvVars:     []string{"LILY_JOB_STOP_ON_ERROR"},
 	Value:       false,
-	Destination: &RunFlags.StopOnFatalError,
+	Destination: &RunFlags.StopOnError,
 }
 
 type notifyOps struct {

--- a/commands/job/options.go
+++ b/commands/job/options.go
@@ -100,7 +100,7 @@ var RunRestartFailure = &cli.BoolFlag{
 
 var StopOnError = &cli.BoolFlag{
 	Name:        "stop-on-error",
-	Usage:       "Stop the job if it get error.",
+	Usage:       "Stop the job if it encounters an error.",
 	EnvVars:     []string{"LILY_JOB_STOP_ON_ERROR"},
 	Value:       false,
 	Destination: &RunFlags.StopOnError,

--- a/lens/lily/api.go
+++ b/lens/lily/api.go
@@ -95,7 +95,7 @@ type LilyJobConfig struct {
 	// RestartOnCompletion when true will restart the job when it completes.
 	RestartOnCompletion bool
 	// RestartOnCompletion when true will restart the job when it completes.
-	StopOnFatalError bool
+	StopOnError bool
 	// RestartDelay configures how long to wait before restarting the job.
 	RestartDelay time.Duration
 	// Storage is the name of the storage system the job will use, may be empty.

--- a/lens/lily/api.go
+++ b/lens/lily/api.go
@@ -94,6 +94,8 @@ type LilyJobConfig struct {
 	RestartOnFailure bool
 	// RestartOnCompletion when true will restart the job when it completes.
 	RestartOnCompletion bool
+	// RestartOnCompletion when true will restart the job when it completes.
+	StopOnFatalError bool
 	// RestartDelay configures how long to wait before restarting the job.
 	RestartDelay time.Duration
 	// Storage is the name of the storage system the job will use, may be empty.

--- a/lens/lily/impl.go
+++ b/lens/lily/impl.go
@@ -328,7 +328,7 @@ func (m *LilyNodeAPI) LilyWalk(_ context.Context, cfg *LilyWalkConfig) (*schedul
 		RestartOnFailure:    cfg.JobConfig.RestartOnFailure,
 		RestartOnCompletion: cfg.JobConfig.RestartOnCompletion,
 		RestartDelay:        cfg.JobConfig.RestartDelay,
-		Job:                 walk.NewWalker(idx, m, cfg.JobConfig.Name, cfg.JobConfig.Tasks, cfg.From, cfg.To, reporter, cfg.JobConfig.StopOnFatalError),
+		Job:                 walk.NewWalker(idx, m, cfg.JobConfig.Name, cfg.JobConfig.Tasks, cfg.From, cfg.To, reporter, cfg.JobConfig.StopOnError),
 		Reporter:            reporter,
 	}
 
@@ -356,7 +356,7 @@ func (m *LilyNodeAPI) LilyWalkNotify(_ context.Context, cfg *LilyWalkNotifyConfi
 		RestartOnFailure:    cfg.WalkConfig.JobConfig.RestartOnFailure,
 		RestartOnCompletion: cfg.WalkConfig.JobConfig.RestartOnCompletion,
 		RestartDelay:        cfg.WalkConfig.JobConfig.RestartDelay,
-		Job:                 walk.NewWalker(idx, m, cfg.WalkConfig.JobConfig.Name, cfg.WalkConfig.JobConfig.Tasks, cfg.WalkConfig.From, cfg.WalkConfig.To, reporter, cfg.WalkConfig.JobConfig.StopOnFatalError),
+		Job:                 walk.NewWalker(idx, m, cfg.WalkConfig.JobConfig.Name, cfg.WalkConfig.JobConfig.Tasks, cfg.WalkConfig.From, cfg.WalkConfig.To, reporter, cfg.WalkConfig.JobConfig.StopOnError),
 		Reporter:            reporter,
 	}
 	res := m.Scheduler.Submit(jobConfig)

--- a/lens/lily/impl.go
+++ b/lens/lily/impl.go
@@ -328,7 +328,7 @@ func (m *LilyNodeAPI) LilyWalk(_ context.Context, cfg *LilyWalkConfig) (*schedul
 		RestartOnFailure:    cfg.JobConfig.RestartOnFailure,
 		RestartOnCompletion: cfg.JobConfig.RestartOnCompletion,
 		RestartDelay:        cfg.JobConfig.RestartDelay,
-		Job:                 walk.NewWalker(idx, m, cfg.JobConfig.Name, cfg.JobConfig.Tasks, cfg.From, cfg.To, reporter),
+		Job:                 walk.NewWalker(idx, m, cfg.JobConfig.Name, cfg.JobConfig.Tasks, cfg.From, cfg.To, reporter, cfg.JobConfig.StopOnFatalError),
 		Reporter:            reporter,
 	}
 
@@ -356,7 +356,7 @@ func (m *LilyNodeAPI) LilyWalkNotify(_ context.Context, cfg *LilyWalkNotifyConfi
 		RestartOnFailure:    cfg.WalkConfig.JobConfig.RestartOnFailure,
 		RestartOnCompletion: cfg.WalkConfig.JobConfig.RestartOnCompletion,
 		RestartDelay:        cfg.WalkConfig.JobConfig.RestartDelay,
-		Job:                 walk.NewWalker(idx, m, cfg.WalkConfig.JobConfig.Name, cfg.WalkConfig.JobConfig.Tasks, cfg.WalkConfig.From, cfg.WalkConfig.To, reporter),
+		Job:                 walk.NewWalker(idx, m, cfg.WalkConfig.JobConfig.Name, cfg.WalkConfig.JobConfig.Tasks, cfg.WalkConfig.From, cfg.WalkConfig.To, reporter, cfg.WalkConfig.JobConfig.StopOnFatalError),
 		Reporter:            reporter,
 	}
 	res := m.Scheduler.Submit(jobConfig)


### PR DESCRIPTION
This pull request can resolve the issue: https://github.com/filecoin-project/lily/issues/1210.

### Usage
By default, when the stopOnFatalError flag is set to false, the process will continue from start to end without halting, regardless of any errors encountered.

To turn on the flag: `--stop-on-error=true`
```
./lily job run --storage=CSV --tasks="fevm_block_header"  --stop-on-error=true walk --from=566400 --to=566405
```