### PR TITLE
feat: add human readable actor codes in fevm_traces

### DIFF
--- a/model/fevm/trace.go
+++ b/model/fevm/trace.go
@@ -57,9 +57,9 @@ type FEVMTrace struct {
 	// Returns codec.
 	ReturnsCodec uint64 `pg:",notnull,use_zero"`
 	// Human-readable identifier of receiver (To).
-	ToActorCode string `pg:",notnull"`
+	ToActorName string `pg:",notnull"`
 	// Human-readable identifier of sender (From).
-	FromActorCode string `pg:",notnull"`
+	FromActorName string `pg:",notnull"`
 }
 
 func (f *FEVMTrace) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {

--- a/model/fevm/trace.go
+++ b/model/fevm/trace.go
@@ -38,7 +38,7 @@ type FEVMTrace struct {
 	Method uint64 `pg:",notnull,use_zero"`
 	// Method in readable name.
 	ParsedMethod string `pg:",notnull"`
-	// ActorCode of To (receiver).
+	// ActorCode of To (receiver) as a CID.
 	ActorCode string `pg:",notnull"`
 	// ExitCode of message execution.
 	ExitCode int64 `pg:",notnull,use_zero"`
@@ -56,6 +56,10 @@ type FEVMTrace struct {
 	ParamsCodec uint64 `pg:",notnull,use_zero"`
 	// Returns codec.
 	ReturnsCodec uint64 `pg:",notnull,use_zero"`
+	// Human-readable identifier of receiver (To).
+	ToActorCode string `pg:",notnull"`
+	// Human-readable identifier of sender (From).
+	FromActorCode string `pg:",notnull"`
 }
 
 func (f *FEVMTrace) Persist(ctx context.Context, s model.StorageBatch, version model.Version) error {

--- a/schemas/v1/28_add_actor_names_to_fevm_traces.go
+++ b/schemas/v1/28_add_actor_names_to_fevm_traces.go
@@ -5,13 +5,13 @@ func init() {
 		28,
 		`
 	ALTER TABLE {{ .SchemaName | default "public"}}.fevm_traces
-		ADD COLUMN IF NOT EXISTS "to_actor_code" text NOT NULL;
+		ADD COLUMN IF NOT EXISTS "to_actor_name" text NOT NULL;
 	
 	ALTER TABLE {{ .SchemaName | default "public"}}.fevm_traces
-		ADD COLUMN IF NOT EXISTS "from_actor_code" text NOT NULL;
+		ADD COLUMN IF NOT EXISTS "from_actor_name" text NOT NULL;
 	
-	COMMENT ON COLUMN {{ .SchemaName | default "public"}}.fevm_traces.to_actor_code IS 'Fully-versioned human-readable identifier of receiver (To).';
-	COMMENT ON COLUMN {{ .SchemaName | default "public"}}.fevm_traces.from_actor_code IS 'Fully-versioned human-readable identifier of receiver (From).';
+	COMMENT ON COLUMN {{ .SchemaName | default "public"}}.fevm_traces.to_actor_name IS 'Fully-versioned human-readable identifier of receiver (To).';
+	COMMENT ON COLUMN {{ .SchemaName | default "public"}}.fevm_traces.from_actor_name IS 'Fully-versioned human-readable identifier of receiver (From).';
 `,
 	)
 }

--- a/schemas/v1/28_add_actor_names_to_fevm_traces.go
+++ b/schemas/v1/28_add_actor_names_to_fevm_traces.go
@@ -1,0 +1,17 @@
+package v1
+
+func init() {
+	patches.Register(
+		28,
+		`
+	ALTER TABLE {{ .SchemaName | default "public"}}.fevm_traces
+		ADD COLUMN IF NOT EXISTS "to_actor_code" text NOT NULL;
+	
+	ALTER TABLE {{ .SchemaName | default "public"}}.fevm_traces
+		ADD COLUMN IF NOT EXISTS "from_actor_code" text NOT NULL;
+	
+	COMMENT ON COLUMN {{ .SchemaName | default "public"}}.fevm_traces.to_actor_code IS 'Fully-versioned human-readable identifier of receiver (To).';
+	COMMENT ON COLUMN {{ .SchemaName | default "public"}}.fevm_traces.from_actor_code IS 'Fully-versioned human-readable identifier of receiver (From).';
+`,
+	)
+}

--- a/tasks/fevm/trace/task.go
+++ b/tasks/fevm/trace/task.go
@@ -119,7 +119,7 @@ func (t *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 		}
 		for _, child := range util.GetChildMessagesOf(parentMsg) {
 			fromCode, _ := getActorCode(ctx, child.Message.From)
-			fromActorCode := "<Unknown>"
+			var fromActorCode string
 			if !fromCode.Equals(cid.Undef) {
 				fromActorCode, _, err = util.ActorNameAndFamilyFromCode(fromCode)
 				if err != nil {
@@ -129,7 +129,7 @@ func (t *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 
 			toCode, _ := getActorCode(ctx, child.Message.To)
 			actorCode := "<Unknown>"
-			toActorCode := "<Unknown>"
+			var toActorCode string
 			if !toCode.Equals(cid.Undef) {
 				actorCode = toCode.String()
 				toActorCode, _, err = util.ActorNameAndFamilyFromCode(toCode)

--- a/tasks/fevm/trace/task.go
+++ b/tasks/fevm/trace/task.go
@@ -159,8 +159,8 @@ func (t *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 				Returns:             ethtypes.EthBytes(child.Receipt.Return).String(),
 				ParamsCodec:         child.Message.ParamsCodec,
 				ReturnsCodec:        child.Receipt.ReturnCodec,
-				ToActorCode:         toActorCode,
-				FromActorCode:       fromActorCode,
+				ToActorName:         toActorCode,
+				FromActorName:       fromActorCode,
 			}
 
 			// only parse params and return of successful messages since unsuccessful messages don't return a parseable value.


### PR DESCRIPTION
This feature adds human-readable actor codes for sender and receiver to fulfill an offline request via Slack from @ychiaoli18.

This should make queries necessary for the FEVM analyses faster as it will no longer require merges with the actors table.