### PR TITLE
fix: skip StateListActors if there is no actor dump processor

### DIFF
--- a/chain/indexer/integrated/processor/state.go
+++ b/chain/indexer/integrated/processor/state.go
@@ -421,6 +421,10 @@ func (sp *StateProcessor) startPeriodicActorDump(ctx context.Context, current *t
 	start := time.Now()
 	var taskNames []string
 
+	if len(sp.periodicActorDumpProcessors) == 0 {
+		return taskNames
+	}
+
 	if interval > 0 && current.Height()%abi.ChainEpoch(interval) != 0 {
 		logger := log.With("processor", "PeriodicActorDump")
 		logger.Infow("Skip this epoch", current.Height())


### PR DESCRIPTION
If there is no `periodicActorDumpProcessors` in the watch or walk, then we do not have to run the `StateListActors`.