### PR TITLE
chore: Change the pkey of fevm_traces and refine the previous migration script

### DIFF
--- a/model/fevm/trace.go
+++ b/model/fevm/trace.go
@@ -15,14 +15,14 @@ type FEVMTrace struct {
 	// Height message was executed at.
 	Height int64 `pg:",pk,notnull,use_zero"`
 	// StateRoot message was applied to.
-	MessageStateRoot string `pg:",pk,notnull"`
+	MessageStateRoot string `pg:",notnull"`
 	// On-chain message triggering the message.
 	MessageCid string `pg:",pk,notnull"`
 	// On-chain message ETH transaction hash
 	TransactionHash string `pg:",notnull"`
 
 	// Cid of the trace.
-	TraceCid string `pg:",pk,notnull"`
+	TraceCid string `pg:",notnull"`
 	// ETH Address of the sender.
 	From string `pg:",notnull"`
 	// ETH Address of the receiver.
@@ -47,7 +47,7 @@ type FEVMTrace struct {
 	// Returns value of message receipt encode in eth bytes.
 	Returns string `pg:",notnull"`
 	// Index indicating the order of the messages execution.
-	Index uint64 `pg:",notnull,use_zero"`
+	Index uint64 `pg:",pk,notnull,use_zero"`
 	// Params contained in message.
 	ParsedParams string `pg:",type:jsonb"`
 	// Returns value of message receipt.

--- a/schemas/v1/30_fevm_actor_dumps.go
+++ b/schemas/v1/30_fevm_actor_dumps.go
@@ -15,8 +15,8 @@ func init() {
 		actor_name           TEXT,
 		PRIMARY KEY(height, actor_id, nonce)
 	);
-	CREATE INDEX fevm_actor_dumps_actor_id_idx ON {{ .SchemaName | default "public"}}.fevm_actor_dumps USING hash (actor_id);
-	CREATE INDEX fevm_actor_dumps_eth_address_idx ON {{ .SchemaName | default "public"}}.fevm_actor_dumps USING hash (eth_address);
+	CREATE INDEX IF NOT EXISTS fevm_actor_dumps_actor_id_idx ON {{ .SchemaName | default "public"}}.fevm_actor_dumps USING hash (actor_id);
+	CREATE INDEX IF NOT EXISTS fevm_actor_dumps_eth_address_idx ON {{ .SchemaName | default "public"}}.fevm_actor_dumps USING hash (eth_address);
 `,
 	)
 }

--- a/schemas/v1/32_change_the_fevm_trace_pkey.go
+++ b/schemas/v1/32_change_the_fevm_trace_pkey.go
@@ -1,0 +1,10 @@
+package v1
+
+func init() {
+	patches.Register(
+		32,
+		`
+		ALTER TABLE {{ .SchemaName | default "public"}}.fevm_traces DROP CONSTRAINT IF EXISTS fevm_traces_pkey CASCADE, ADD PRIMARY KEY(height, index, message_cid)
+`,
+	)
+}


### PR DESCRIPTION
Try to make the `fevm_trace`' primary key be more simple and unique.