### PR TITLE
feat: add new job to find out orphan block

### DIFF
--- a/commands/sync.go
+++ b/commands/sync.go
@@ -410,7 +410,10 @@ func detectOrphanBlocks(ctx context.Context, lapi lily.LilyAPI, state *SyncingSt
 
 				// To do set the orphan to Storage
 				if len(orphanBlocks) > 0 && state.Storage != nil {
-					state.PersistBlocks(ctx, orphanBlocks)
+					err := state.PersistBlocks(ctx, orphanBlocks)
+					if err != nil {
+						log.Errorf("Error at persisting the orphan blocks: %v", err)
+					}
 				}
 			}
 		}

--- a/commands/sync.go
+++ b/commands/sync.go
@@ -323,9 +323,9 @@ func getSubBlocks(ctx context.Context, lapi lily.LilyAPI, strg model.Storage) {
 		} else {
 			result := blocks.UnsyncedBlockHeaders{}
 			result = append(result, block)
-			strg.PersistBatch(ctx, result)
+			err = strg.PersistBatch(ctx, result)
 			if err != nil {
-				log.Error(err)
+				log.Errorf("Error at persisting the unsynced block headers: %v", err)
 			}
 		}
 	}

--- a/commands/util.go
+++ b/commands/util.go
@@ -1,13 +1,20 @@
 package commands
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/urfave/cli/v2"
 
+	"github.com/filecoin-project/lily/config"
+	"github.com/filecoin-project/lily/model"
 	"github.com/filecoin-project/lily/schedule"
+	"github.com/filecoin-project/lily/storage"
 )
 
 func FlagSet(fs ...[]cli.Flag) []cli.Flag {
@@ -29,4 +36,47 @@ func PrintNewJob(w io.Writer, res *schedule.JobSubmitResult) error {
 		return err
 	}
 	return nil
+}
+
+func SetupContextWithCancel(ctx context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(ctx)
+
+	go func() {
+		interrupt := make(chan os.Signal, 1)
+		signal.Notify(interrupt, syscall.SIGTERM, syscall.SIGINT)
+		select {
+		case <-interrupt:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	return ctx, cancel
+}
+
+func SetupStorage(configPath string, storageStr string) (strg model.Storage, err error) {
+	if storageStr != "" {
+		cfg, err := config.FromFile(configPath)
+		if err != nil {
+			return nil, err
+		}
+
+		md := storage.Metadata{
+			JobName: storageStr,
+		}
+
+		// context for db connection
+		ctxDB := context.Background()
+
+		sc, err := storage.NewCatalog(cfg.Storage)
+		if err != nil {
+			return nil, err
+		}
+		strg, err = sc.Connect(ctxDB, syncFlags.storage, md)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return strg, nil
 }

--- a/lens/lily/api.go
+++ b/lens/lily/api.go
@@ -62,6 +62,10 @@ type LilyAPI interface {
 	EthGetTransactionByHash(ctx context.Context, txHash *ethtypes.EthHash) (*ethtypes.EthTx, error)              //perm:read
 	StateListActors(ctx context.Context, tsk types.TipSetKey) ([]address.Address, error)                         //perm:read
 
+	// SyncIncomingBlocks returns a channel streaming incoming, potentially not
+	// yet synced block headers.
+	SyncIncomingBlocks(ctx context.Context) (<-chan *types.BlockHeader, error) //perm:read
+
 	// trigger graceful shutdown
 	Shutdown(context.Context) error
 

--- a/lens/lily/struct.go
+++ b/lens/lily/struct.go
@@ -71,6 +71,10 @@ type LilyAPIStruct struct {
 		EthGetTransactionByHash   func(ctx context.Context, txHash *ethtypes.EthHash) (*ethtypes.EthTx, error)                    `perm:"read"`
 		StateListActors           func(ctx context.Context, tsk types.TipSetKey) ([]address.Address, error)                       `perm:"read"`
 
+		// SyncIncomingBlocks returns a channel streaming incoming, potentially not
+		// yet synced block headers.
+		SyncIncomingBlocks func(ctx context.Context) (<-chan *types.BlockHeader, error) `perm:"read"`
+
 		LogList          func(context.Context) ([]string, error)     `perm:"read"`
 		LogSetLevel      func(context.Context, string, string) error `perm:"read"`
 		LogSetLevelRegex func(context.Context, string, string) error `perm:"read"`
@@ -294,4 +298,8 @@ func (s *LilyAPIStruct) StateListActors(ctx context.Context, tsk types.TipSetKey
 
 func (s *LilyAPIStruct) EthGetTransactionByHash(ctx context.Context, txHash *ethtypes.EthHash) (*ethtypes.EthTx, error) {
 	return s.Internal.EthGetTransactionByHash(ctx, txHash)
+}
+
+func (s *LilyAPIStruct) SyncIncomingBlocks(ctx context.Context) (<-chan *types.BlockHeader, error) {
+	return s.Internal.SyncIncomingBlocks(ctx)
 }

--- a/model/blocks/unsynced_header.go
+++ b/model/blocks/unsynced_header.go
@@ -22,6 +22,7 @@ type UnsyncedBlockHeader struct {
 	WinCount      int64  `pg:",use_zero"`
 	Timestamp     uint64 `pg:",use_zero"`
 	ForkSignaling uint64 `pg:",use_zero"`
+	IsOrphan      bool   `pg:",notnull"`
 }
 
 func NewUnsyncedBlockHeader(bh *types.BlockHeader) *UnsyncedBlockHeader {
@@ -35,6 +36,7 @@ func NewUnsyncedBlockHeader(bh *types.BlockHeader) *UnsyncedBlockHeader {
 		WinCount:        bh.ElectionProof.WinCount,
 		Timestamp:       bh.Timestamp,
 		ForkSignaling:   bh.ForkSignaling,
+		IsOrphan:        false,
 	}
 }
 

--- a/model/blocks/unsynced_header.go
+++ b/model/blocks/unsynced_header.go
@@ -1,0 +1,62 @@
+package blocks
+
+import (
+	"context"
+
+	"github.com/filecoin-project/lily/metrics"
+	"github.com/filecoin-project/lily/model"
+	"github.com/filecoin-project/lotus/chain/types"
+	"go.opencensus.io/tag"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+type UnsyncedBlockHeader struct {
+	Height          int64  `pg:",pk,use_zero,notnull"`
+	Cid             string `pg:",pk,notnull"`
+	Miner           string `pg:",notnull"`
+	ParentWeight    string `pg:",notnull"`
+	ParentBaseFee   string `pg:",notnull"`
+	ParentStateRoot string `pg:",notnull"`
+
+	WinCount      int64  `pg:",use_zero"`
+	Timestamp     uint64 `pg:",use_zero"`
+	ForkSignaling uint64 `pg:",use_zero"`
+}
+
+func NewUnsyncedBlockHeader(bh *types.BlockHeader) *UnsyncedBlockHeader {
+	return &UnsyncedBlockHeader{
+		Cid:             bh.Cid().String(),
+		Miner:           bh.Miner.String(),
+		ParentWeight:    bh.ParentWeight.String(),
+		ParentBaseFee:   bh.ParentBaseFee.String(),
+		ParentStateRoot: bh.ParentStateRoot.String(),
+		Height:          int64(bh.Height),
+		WinCount:        bh.ElectionProof.WinCount,
+		Timestamp:       bh.Timestamp,
+		ForkSignaling:   bh.ForkSignaling,
+	}
+}
+
+func (bh *UnsyncedBlockHeader) Persist(ctx context.Context, s model.StorageBatch, _ model.Version) error {
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "unsynced_block_headers"))
+	metrics.RecordCount(ctx, metrics.PersistModel, 1)
+	return s.PersistModel(ctx, bh)
+}
+
+type UnsyncedBlockHeaders []*UnsyncedBlockHeader
+
+func (bhl UnsyncedBlockHeaders) Persist(ctx context.Context, s model.StorageBatch, _ model.Version) error {
+	if len(bhl) == 0 {
+		return nil
+	}
+	ctx, span := otel.Tracer("").Start(ctx, "UnsyncedBlockHeaders.Persist")
+	if span.IsRecording() {
+		span.SetAttributes(attribute.Int("count", len(bhl)))
+	}
+	defer span.End()
+
+	ctx, _ = tag.New(ctx, tag.Upsert(metrics.Table, "block_headers"))
+	metrics.RecordCount(ctx, metrics.PersistModel, len(bhl))
+	return s.PersistModel(ctx, bhl)
+}

--- a/schemas/v1/33_unsynced_block_headers.go
+++ b/schemas/v1/33_unsynced_block_headers.go
@@ -1,0 +1,24 @@
+package v1
+
+func init() {
+	patches.Register(
+		33,
+		`
+	CREATE TABLE IF NOT EXISTS {{ .SchemaName | default "public"}}.unsynced_block_headers (
+		height            BIGINT NOT NULL,
+		cid               TEXT NOT NULL,
+		miner             TEXT,
+		parent_weight     TEXT,
+		parent_base_fee   TEXT,
+		parent_state_root TEXT,
+		win_count         BIGINT,
+		"timestamp"       BIGINT,
+		fork_signaling    BIGINT,
+		PRIMARY KEY(height, cid)
+	);
+	CREATE INDEX IF NOT EXISTS unsynced_block_headers_height_idx ON {{ .SchemaName | default "public"}}.unsynced_block_headers USING btree (height DESC);
+	CREATE INDEX IF NOT EXISTS unsynced_block_headers_timestamp_idx ON {{ .SchemaName | default "public"}}.unsynced_block_headers USING btree ("timestamp");
+	CREATE INDEX IF NOT EXISTS unsynced_block_headers_miner_idx ON {{ .SchemaName | default "public"}}.unsynced_block_headers USING hash (miner);
+`,
+	)
+}

--- a/schemas/v1/34_unsynced_block_headers.go
+++ b/schemas/v1/34_unsynced_block_headers.go
@@ -2,7 +2,7 @@ package v1
 
 func init() {
 	patches.Register(
-		33,
+		34,
 		`
 	CREATE TABLE IF NOT EXISTS {{ .SchemaName | default "public"}}.unsynced_block_headers (
 		height            BIGINT NOT NULL,
@@ -14,6 +14,7 @@ func init() {
 		win_count         BIGINT,
 		"timestamp"       BIGINT,
 		fork_signaling    BIGINT,
+		is_orphan         BOOLEAN,
 		PRIMARY KEY(height, cid)
 	);
 	CREATE INDEX IF NOT EXISTS unsynced_block_headers_height_idx ON {{ .SchemaName | default "public"}}.unsynced_block_headers USING btree (height DESC);


### PR DESCRIPTION
This command allows users to monitor the occurrence frequency of orphan blocks in real-time, providing insights into the health status of the blockchain or for post-analysis purposes.

![截圖 2023-10-02 下午6 17 58](https://github.com/filecoin-project/lily/assets/4417105/17413d54-9c9e-4b3f-93cb-94f23822ecd0)
