### PR TITLE
feat: Add new function for filtering invalid message

### DIFF
--- a/chain/datasource/datasource.go
+++ b/chain/datasource/datasource.go
@@ -147,6 +147,10 @@ func (t *DataSource) TipSetBlockMessages(ctx context.Context, ts *types.TipSet) 
 	return t.node.MessagesForTipSetBlocks(ctx, ts)
 }
 
+func (t *DataSource) MessagesWithDeduplicationForTipSet(ctx context.Context, ts *types.TipSet) ([]types.ChainMsg, error) {
+	return t.node.MessagesWithDeduplicationForTipSet(ctx, ts)
+}
+
 func (t *DataSource) StateListActors(ctx context.Context, tsk types.TipSetKey) ([]address.Address, error) {
 	return t.node.StateListActors(ctx, tsk)
 }

--- a/chain/datasource/datasource.go
+++ b/chain/datasource/datasource.go
@@ -147,7 +147,7 @@ func (t *DataSource) TipSetBlockMessages(ctx context.Context, ts *types.TipSet) 
 	return t.node.MessagesForTipSetBlocks(ctx, ts)
 }
 
-func (t *DataSource) MessagesWithDeduplicationForTipSet(ctx context.Context, ts *types.TipSet) ([]types.ChainMsg, error) {
+func (t *DataSource) MessagesWithDeduplicationForTipSet(ctx context.Context, ts *types.TipSet) (map[cid.Cid]types.ChainMsg, error) {
 	return t.node.MessagesWithDeduplicationForTipSet(ctx, ts)
 }
 

--- a/lens/interface.go
+++ b/lens/interface.go
@@ -51,6 +51,7 @@ type ChainAPI interface {
 
 	MessagesForTipSetBlocks(ctx context.Context, ts *types.TipSet) ([]*BlockMessages, error)
 	TipSetMessageReceipts(ctx context.Context, ts, pts *types.TipSet) ([]*BlockMessageReceipts, error)
+	MessagesWithDeduplicationForTipSet(ctx context.Context, ts *types.TipSet) ([]types.ChainMsg, error)
 
 	// added during hyperspace
 	ChainGetEvents(ctx context.Context, root cid.Cid) ([]types.Event, error)

--- a/lens/interface.go
+++ b/lens/interface.go
@@ -51,7 +51,7 @@ type ChainAPI interface {
 
 	MessagesForTipSetBlocks(ctx context.Context, ts *types.TipSet) ([]*BlockMessages, error)
 	TipSetMessageReceipts(ctx context.Context, ts, pts *types.TipSet) ([]*BlockMessageReceipts, error)
-	MessagesWithDeduplicationForTipSet(ctx context.Context, ts *types.TipSet) ([]types.ChainMsg, error)
+	MessagesWithDeduplicationForTipSet(ctx context.Context, ts *types.TipSet) (map[cid.Cid]types.ChainMsg, error)
 
 	// added during hyperspace
 	ChainGetEvents(ctx context.Context, root cid.Cid) ([]types.Event, error)

--- a/lens/lily/impl.go
+++ b/lens/lily/impl.go
@@ -594,11 +594,10 @@ func (m *LilyNodeAPI) MessagesForTipSetBlocks(ctx context.Context, ts *types.Tip
 
 func (m *LilyNodeAPI) MessagesWithDeduplicationForTipSet(ctx context.Context, ts *types.TipSet) (map[cid.Cid]types.ChainMsg, error) {
 	blkMsgs, err := m.ChainAPI.Chain.BlockMsgsForTipset(ctx, ts)
-	if err != nil {
-		return nil, err
-	}
-
 	msgMap := make(map[cid.Cid]types.ChainMsg)
+	if err != nil {
+		return msgMap, err
+	}
 	for _, blk := range blkMsgs {
 		for _, msg := range blk.BlsMessages {
 			msgMap[msg.Cid()] = msg

--- a/lens/lily/impl.go
+++ b/lens/lily/impl.go
@@ -592,6 +592,21 @@ func (m *LilyNodeAPI) MessagesForTipSetBlocks(ctx context.Context, ts *types.Tip
 	return out, nil
 }
 
+func (m *LilyNodeAPI) MessagesWithDeduplicationForTipSet(ctx context.Context, ts *types.TipSet) ([]types.ChainMsg, error) {
+	blkMsgs, err := m.ChainAPI.Chain.BlockMsgsForTipset(ctx, ts)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []types.ChainMsg
+	for _, blk := range blkMsgs {
+		out = append(out, blk.BlsMessages...)
+		out = append(out, blk.SecpkMessages...)
+	}
+
+	return out, nil
+}
+
 // TipSetMessageReceipts returns the blocks and messages in `pts` and their corresponding receipts from `ts` matching block order in tipset (`pts`).
 func (m *LilyNodeAPI) TipSetMessageReceipts(ctx context.Context, ts, pts *types.TipSet) ([]*lens.BlockMessageReceipts, error) {
 	// sanity check args

--- a/lens/lily/impl.go
+++ b/lens/lily/impl.go
@@ -592,19 +592,23 @@ func (m *LilyNodeAPI) MessagesForTipSetBlocks(ctx context.Context, ts *types.Tip
 	return out, nil
 }
 
-func (m *LilyNodeAPI) MessagesWithDeduplicationForTipSet(ctx context.Context, ts *types.TipSet) ([]types.ChainMsg, error) {
+func (m *LilyNodeAPI) MessagesWithDeduplicationForTipSet(ctx context.Context, ts *types.TipSet) (map[cid.Cid]types.ChainMsg, error) {
 	blkMsgs, err := m.ChainAPI.Chain.BlockMsgsForTipset(ctx, ts)
 	if err != nil {
 		return nil, err
 	}
 
-	var out []types.ChainMsg
+	msgMap := make(map[cid.Cid]types.ChainMsg)
 	for _, blk := range blkMsgs {
-		out = append(out, blk.BlsMessages...)
-		out = append(out, blk.SecpkMessages...)
+		for _, msg := range blk.BlsMessages {
+			msgMap[msg.Cid()] = msg
+		}
+		for _, msg := range blk.SecpkMessages {
+			msgMap[msg.Cid()] = msg
+		}
 	}
 
-	return out, nil
+	return msgMap, nil
 }
 
 // TipSetMessageReceipts returns the blocks and messages in `pts` and their corresponding receipts from `ts` matching block order in tipset (`pts`).

--- a/tasks/api.go
+++ b/tasks/api.go
@@ -70,6 +70,7 @@ type DataSource interface {
 
 	TipSetMessageReceipts(ctx context.Context, ts, pts *types.TipSet) ([]*lens.BlockMessageReceipts, error)
 	MessageReceiptEvents(ctx context.Context, root cid.Cid) ([]types.Event, error)
+	MessagesWithDeduplicationForTipSet(ctx context.Context, ts *types.TipSet) ([]types.ChainMsg, error)
 
 	DiffSectors(ctx context.Context, addr address.Address, ts, pts *types.TipSet, pre, cur miner.State) (*miner.SectorChanges, error)
 	DiffPreCommits(ctx context.Context, addr address.Address, ts, pts *types.TipSet, pre, cur miner.State) (*miner.PreCommitChanges, error)

--- a/tasks/api.go
+++ b/tasks/api.go
@@ -70,7 +70,7 @@ type DataSource interface {
 
 	TipSetMessageReceipts(ctx context.Context, ts, pts *types.TipSet) ([]*lens.BlockMessageReceipts, error)
 	MessageReceiptEvents(ctx context.Context, root cid.Cid) ([]types.Event, error)
-	MessagesWithDeduplicationForTipSet(ctx context.Context, ts *types.TipSet) ([]types.ChainMsg, error)
+	MessagesWithDeduplicationForTipSet(ctx context.Context, ts *types.TipSet) (map[cid.Cid]types.ChainMsg, error)
 
 	DiffSectors(ctx context.Context, addr address.Address, ts, pts *types.TipSet, pre, cur miner.State) (*miner.SectorChanges, error)
 	DiffPreCommits(ctx context.Context, addr address.Address, ts, pts *types.TipSet, pre, cur miner.State) (*miner.PreCommitChanges, error)

--- a/tasks/messages/gaseconomy/task.go
+++ b/tasks/messages/gaseconomy/task.go
@@ -49,6 +49,9 @@ func (t *Task) ProcessTipSet(ctx context.Context, current *types.TipSet) (model.
 	}
 
 	validMsgCid, err := t.node.MessagesWithDeduplicationForTipSet(ctx, current)
+	if err != nil {
+		log.Errorf("Error at getting messages with deduplication: %v", err)
+	}
 
 	log.Infof("Get the count of valid messages: %v", len(validMsgCid))
 

--- a/tasks/messages/gaseconomy/task.go
+++ b/tasks/messages/gaseconomy/task.go
@@ -48,16 +48,7 @@ func (t *Task) ProcessTipSet(ctx context.Context, current *types.TipSet) (model.
 		StateRoot: current.ParentState().String(),
 	}
 
-	validMsgCid := make(map[cid.Cid]bool)
-	uniqMsg, err := t.node.MessagesWithDeduplicationForTipSet(ctx, current)
-	if err != nil {
-		log.Errorf("Error at getting messages with deduplication: %v", err)
-	}
-	if uniqMsg != nil {
-		for _, msg := range uniqMsg {
-			validMsgCid[msg.Cid()] = true
-		}
-	}
+	validMsgCid, err := t.node.MessagesWithDeduplicationForTipSet(ctx, current)
 
 	log.Infof("Get the count of valid messages: %v", len(validMsgCid))
 

--- a/tasks/messages/gaseconomy/task.go
+++ b/tasks/messages/gaseconomy/task.go
@@ -16,6 +16,8 @@ import (
 	messagemodel "github.com/filecoin-project/lily/model/messages"
 	visormodel "github.com/filecoin-project/lily/model/visor"
 	"github.com/filecoin-project/lily/tasks"
+
+	logging "github.com/ipfs/go-log/v2"
 )
 
 type Task struct {
@@ -27,6 +29,8 @@ func NewTask(node tasks.DataSource) *Task {
 		node: node,
 	}
 }
+
+var log = logging.Logger("lily/tasks/gaseconomy")
 
 func (t *Task) ProcessTipSet(ctx context.Context, current *types.TipSet) (model.Persistable, *visormodel.ProcessingReport, error) {
 	ctx, span := otel.Tracer("").Start(ctx, "ProcessTipSet")
@@ -43,6 +47,19 @@ func (t *Task) ProcessTipSet(ctx context.Context, current *types.TipSet) (model.
 		Height:    int64(current.Height()),
 		StateRoot: current.ParentState().String(),
 	}
+
+	validMsgCid := make(map[cid.Cid]bool)
+	uniqMsg, err := t.node.MessagesWithDeduplicationForTipSet(ctx, current)
+	if err != nil {
+		log.Errorf("Error at getting messages with deduplication: %v", err)
+	}
+	if uniqMsg != nil {
+		for _, msg := range uniqMsg {
+			validMsgCid[msg.Cid()] = true
+		}
+	}
+
+	log.Infof("Get the count of valid messages: %v", len(validMsgCid))
 
 	msgrec, err := t.node.TipSetBlockMessages(ctx, current)
 	if err != nil {
@@ -65,6 +82,10 @@ func (t *Task) ProcessTipSet(ctx context.Context, current *types.TipSet) (model.
 		}
 
 		for _, msg := range mr.BlsMessages {
+			if _, exists := validMsgCid[msg.Cid()]; !exists {
+				log.Errorf("Get invalid message cid: %v", msg.Cid())
+				continue
+			}
 			// calculate total gas limit of executed messages regardless of duplicates.
 			totalGasLimit += msg.GasLimit
 			if exeMsgSeen[msg.Cid()] {
@@ -76,6 +97,10 @@ func (t *Task) ProcessTipSet(ctx context.Context, current *types.TipSet) (model.
 
 		}
 		for _, msg := range mr.SecpMessages {
+			if _, exists := validMsgCid[msg.Cid()]; !exists {
+				log.Errorf("Get invalid message cid: %v", msg.Cid())
+				continue
+			}
 			// calculate total gas limit of executed messages regardless of duplicates.
 			totalGasLimit += msg.VMMessage().GasLimit
 			if exeMsgSeen[msg.Cid()] {

--- a/testutil/lens.go
+++ b/testutil/lens.go
@@ -51,6 +51,11 @@ func (aw *APIWrapper) TipSetMessageReceipts(ctx context.Context, ts, pts *types.
 	panic("implement me")
 }
 
+func (aw *APIWrapper) MessagesWithDeduplicationForTipSet(ctx context.Context, ts *types.TipSet) ([]types.ChainMsg, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (aw *APIWrapper) CirculatingSupply(ctx context.Context, key types.TipSetKey) (api.CirculatingSupply, error) {
 	return aw.StateVMCirculatingSupplyInternal(ctx, key)
 }

--- a/testutil/lens.go
+++ b/testutil/lens.go
@@ -51,7 +51,7 @@ func (aw *APIWrapper) TipSetMessageReceipts(ctx context.Context, ts, pts *types.
 	panic("implement me")
 }
 
-func (aw *APIWrapper) MessagesWithDeduplicationForTipSet(ctx context.Context, ts *types.TipSet) ([]types.ChainMsg, error) {
+func (aw *APIWrapper) MessagesWithDeduplicationForTipSet(ctx context.Context, ts *types.TipSet) (map[cid.Cid]types.ChainMsg, error) {
 	//TODO implement me
 	panic("implement me")
 }


### PR DESCRIPTION
To address the data mismatch problem in `message_gas_economy`, we will rectify the data by utilizing the `BlockMsgsForTipset` function to obtain a valid list of CIDs. Subsequently, we will rerun the same process, incorporating an improved filtering function designed to exclude any invalid CIDs from the analysis.

Try to resolve the issue: https://github.com/filecoin-project/lily/issues/1266