### PR TITLE
feat: add new column for builtin_actor_events

### DIFF
--- a/model/actors/builtinactor/builtinactorevents.go
+++ b/model/actors/builtinactor/builtinactorevents.go
@@ -20,6 +20,7 @@ type BuiltInActorEvent struct {
 	EventType    string `pg:",pk,notnull"`
 	EventEntries string `pg:",type:jsonb"`
 	EventPayload string `pg:",type:jsonb"`
+	EventIdx     int64  `pg:",pk,notnull"`
 }
 
 func (ds *BuiltInActorEvent) Persist(ctx context.Context, s model.StorageBatch, _ model.Version) error {

--- a/schemas/v1/37_change_pkey_builtin_actor_event.go
+++ b/schemas/v1/37_change_pkey_builtin_actor_event.go
@@ -1,0 +1,24 @@
+package v1
+
+func init() {
+	patches.Register(
+		37,
+		`
+	ALTER TABLE {{ .SchemaName | default "public"}}.builtin_actor_events ADD COLUMN IF NOT EXISTS "event_idx" BIGINT DEFAULT 0;
+	ALTER TABLE {{ .SchemaName | default "public"}}.builtin_actor_events DROP CONSTRAINT IF EXISTS builtin_actor_events_pkey CASCADE, ADD PRIMARY KEY(height, cid, emitter, event_type, event_idx);
+
+	CREATE INDEX IF NOT EXISTS builtin_actor_events_emitter_idx ON {{ .SchemaName | default "public"}}.builtin_actor_events USING hash (emitter);
+	CREATE INDEX IF NOT EXISTS builtin_actor_events_event_type_idx ON {{ .SchemaName | default "public"}}.builtin_actor_events USING hash (event_type);
+	CREATE INDEX IF NOT EXISTS builtin_actor_events_height_idx ON {{ .SchemaName | default "public"}}.builtin_actor_events USING btree (height);
+
+	SELECT create_hypertable(
+		'builtin_actor_events',
+		'height',
+		chunk_time_interval => 2880,
+		if_not_exists => TRUE,
+		migrate_data => TRUE
+	);
+	SELECT set_integer_now_func('builtin_actor_events', 'current_height', replace_if_exists => true);
+`,
+	)
+}

--- a/tasks/messages/builtinactorevent/task.go
+++ b/tasks/messages/builtinactorevent/task.go
@@ -240,6 +240,7 @@ func (t *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 			Cid:       event.MsgCid.String(),
 			Emitter:   event.Emitter.String(),
 			EventType: eventType,
+			EventIdx:  int64(evtIdx),
 		}
 
 		re, jsonErr := json.Marshal(eventsSlice)

--- a/tasks/messages/builtinactorevent/task.go
+++ b/tasks/messages/builtinactorevent/task.go
@@ -20,7 +20,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-var log = logging.Logger("lily/tasks/mineractordump")
+var log = logging.Logger("lily/tasks/builtinactorevent")
 
 type Task struct {
 	node tasks.DataSource
@@ -155,7 +155,7 @@ func cborValueDecode(key string, value []byte) interface{} {
 	case CID:
 		err = cbor.Unmarshal(value, &resultCID)
 		if err != nil {
-			log.Errorf("cbor.Unmarshal err: %v, key: %v", err, key)
+			log.Errorf("cbor.Unmarshal err: %v, key: %v, value: %v", err, key, value)
 			return nil
 		}
 		return resultCID


### PR DESCRIPTION
## Description
Add a new column for `builtin_actor_events`: `event_idx`. Moreover, add more index for `builtin_actor_events`. Then covert it into hypertable.
## Migration
```
lily migrate --db="postgres://{user}:{password}@{host}:{port}/lily?sslmode=disable" --name migration --schema {schema} --to 1.37

```