### PR TITLE
fix: use the new library to parse cid from builtin_actor_event

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	github.com/hibiken/asynq v0.23.0
 	github.com/hibiken/asynq/x v0.0.0-20220413130846-5c723f597e01
 	github.com/ipfs/go-ipld-format v0.6.0
+	github.com/ipld/go-ipld-prime v0.21.0
 	github.com/jedib0t/go-pretty/v6 v6.2.7
 	github.com/libp2p/go-libp2p v0.33.2
 	github.com/multiformats/go-varint v0.0.7
@@ -209,7 +210,6 @@ require (
 	github.com/ipld/go-car/v2 v2.13.1 // indirect
 	github.com/ipld/go-codec-dagpb v1.6.0 // indirect
 	github.com/ipld/go-ipld-adl-hamt v0.0.0-20220616142416-9004dbd839e0 // indirect
-	github.com/ipld/go-ipld-prime v0.21.0 // indirect
 	github.com/ipld/go-ipld-selector-text-lite v0.0.1 // indirect
 	github.com/ipni/go-libipni v0.0.8 // indirect
 	github.com/ipni/index-provider v0.12.0 // indirect

--- a/tasks/messages/builtinactorevent/task.go
+++ b/tasks/messages/builtinactorevent/task.go
@@ -16,6 +16,9 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/codec/dagcbor"
+	"github.com/ipld/go-ipld-prime/node/bindnode"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -153,11 +156,12 @@ func cborValueDecode(key string, value []byte) interface{} {
 		}
 		return resultBIGINT
 	case CID:
-		err = cbor.Unmarshal(value, &resultCID)
+		nd, err := ipld.DecodeUsingPrototype(value, dagcbor.Decode, bindnode.Prototype((*cid.Cid)(nil), nil))
 		if err != nil {
 			log.Errorf("cbor.Unmarshal err: %v, key: %v, value: %v", err, key, value)
 			return nil
 		}
+		resultCID = *bindnode.Unwrap(nd).(*cid.Cid)
 		return resultCID
 	}
 


### PR DESCRIPTION
## Description
There is an error during the parsing the cid in `builtin_actor_events`.
```
ERROR	lily/tasks/builtinactorevent	builtinactorevent/task.go:158	cbor.Unmarshal err: invalid cid: invalid cid: expected 1 as the cid version number, got: 0, key: piece-cid, value: [216 42 88 40 0 1 129 226 3 146 32 32 228 70 102 200 187 252 1 84 224 140 131 94 192 12 79 75 10 106 245 208 197 80 239 236 194 115 180 86 152 152 84 41]
```
## Solution
Use the recommended library to parse it: https://github.com/ipld/go-ipld-prime.