### PR TITLE
feat: refine miner_sector_deal_v2 performance issue

### DIFF
--- a/chain/actors/builtin/market/actor.go.template
+++ b/chain/actors/builtin/market/actor.go.template
@@ -106,6 +106,7 @@ type DealProposal = markettypes.DealProposal
 type DealLabel = markettypes.DealLabel
 
 type DealState interface {
+	SectorNumber() abi.SectorNumber
 	SectorStartEpoch() abi.ChainEpoch // -1 if not yet included in proven sector
 	LastUpdatedEpoch() abi.ChainEpoch // -1 if deal state never updated
 	SlashEpoch() abi.ChainEpoch       // -1 if deal never slashed

--- a/chain/actors/builtin/market/actor.go.template
+++ b/chain/actors/builtin/market/actor.go.template
@@ -77,7 +77,7 @@ type State interface {
 	DealStatesAmtBitwidth() int
 
 	GetProviderSectors() (map[abi.SectorID][]abi.DealID, error)
-	GetProviderSectorsByDealID(map[abi.DealID]bool) (map[abi.DealID]abi.SectorID, error)
+	GetProviderSectorsByDealID(map[abi.DealID]bool, map[abi.SectorNumber]bool) (map[abi.DealID]abi.SectorID, error)
 }
 
 type BalanceTable interface {

--- a/chain/actors/builtin/market/market.go
+++ b/chain/actors/builtin/market/market.go
@@ -107,7 +107,7 @@ type State interface {
 	DealStatesAmtBitwidth() int
 
 	GetProviderSectors() (map[abi.SectorID][]abi.DealID, error)
-	GetProviderSectorsByDealID(map[abi.DealID]bool) (map[abi.DealID]abi.SectorID, error)
+	GetProviderSectorsByDealID(map[abi.DealID]bool, map[abi.SectorNumber]bool) (map[abi.DealID]abi.SectorID, error)
 }
 
 type BalanceTable interface {

--- a/chain/actors/builtin/market/market.go
+++ b/chain/actors/builtin/market/market.go
@@ -135,6 +135,7 @@ type DealProposal = markettypes.DealProposal
 type DealLabel = markettypes.DealLabel
 
 type DealState interface {
+	SectorNumber() abi.SectorNumber
 	SectorStartEpoch() abi.ChainEpoch // -1 if not yet included in proven sector
 	LastUpdatedEpoch() abi.ChainEpoch // -1 if deal state never updated
 	SlashEpoch() abi.ChainEpoch       // -1 if deal never slashed
@@ -194,6 +195,10 @@ func (e *emptyDealState) LastUpdatedEpoch() abi.ChainEpoch {
 
 func (e *emptyDealState) SlashEpoch() abi.ChainEpoch {
 	return -1
+}
+
+func (e *emptyDealState) SectorNumber() abi.SectorNumber {
+	return 0
 }
 
 func (e *emptyDealState) Equals(other DealState) bool {

--- a/chain/actors/builtin/market/state.go.template
+++ b/chain/actors/builtin/market/state.go.template
@@ -356,7 +356,7 @@ func (s *state{{.v}}) GetProviderSectors() (map[abi.SectorID][]abi.DealID, error
 	{{end}}
    }
 
-func (s *state{{.v}}) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool) (map[abi.DealID]abi.SectorID, error) {
+func (s *state{{.v}}) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool, sectorIDMap map[abi.SectorNumber]bool) (map[abi.DealID]abi.SectorID, error) {
 	{{if (le .v 12)}}
 	return nil, nil
 	{{else}}
@@ -382,6 +382,10 @@ func (s *state{{.v}}) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool) 
 			sectorNumber, err := abi.ParseUIntKey(sectorID)
 			if err != nil {
 				return err
+			}
+
+			if _, found := sectorIDMap[abi.SectorNumber(sectorNumber)]; !found {
+				return nil
 			}
 
 			dealIDsCopy := make([]abi.DealID, len(dealIDs))

--- a/chain/actors/builtin/market/state.go.template
+++ b/chain/actors/builtin/market/state.go.template
@@ -156,6 +156,14 @@ func (d dealStateV{{.v}}) SectorStartEpoch() abi.ChainEpoch {
 	return d.ds{{.v}}.SectorStartEpoch
 }
 
+func (d dealStateV{{.v}}) SectorNumber() abi.SectorNumber {
+	{{if ge .v 13}}
+	return d.ds{{.v}}.SectorNumber
+	{{else}}
+	return 0
+	{{end}}
+}
+
 func (d dealStateV{{.v}}) LastUpdatedEpoch() abi.ChainEpoch {
 	return d.ds{{.v}}.LastUpdatedEpoch
 }

--- a/chain/actors/builtin/market/v0.go
+++ b/chain/actors/builtin/market/v0.go
@@ -282,7 +282,7 @@ func (s *state0) GetProviderSectors() (map[abi.SectorID][]abi.DealID, error) {
 
 }
 
-func (s *state0) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool) (map[abi.DealID]abi.SectorID, error) {
+func (s *state0) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool, sectorIDMap map[abi.SectorNumber]bool) (map[abi.DealID]abi.SectorID, error) {
 
 	return nil, nil
 

--- a/chain/actors/builtin/market/v0.go
+++ b/chain/actors/builtin/market/v0.go
@@ -139,6 +139,12 @@ func (d dealStateV0) SectorStartEpoch() abi.ChainEpoch {
 	return d.ds0.SectorStartEpoch
 }
 
+func (d dealStateV0) SectorNumber() abi.SectorNumber {
+
+	return 0
+
+}
+
 func (d dealStateV0) LastUpdatedEpoch() abi.ChainEpoch {
 	return d.ds0.LastUpdatedEpoch
 }

--- a/chain/actors/builtin/market/v10.go
+++ b/chain/actors/builtin/market/v10.go
@@ -294,7 +294,7 @@ func (s *state10) GetProviderSectors() (map[abi.SectorID][]abi.DealID, error) {
 
 }
 
-func (s *state10) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool) (map[abi.DealID]abi.SectorID, error) {
+func (s *state10) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool, sectorIDMap map[abi.SectorNumber]bool) (map[abi.DealID]abi.SectorID, error) {
 
 	return nil, nil
 

--- a/chain/actors/builtin/market/v10.go
+++ b/chain/actors/builtin/market/v10.go
@@ -135,6 +135,12 @@ func (d dealStateV10) SectorStartEpoch() abi.ChainEpoch {
 	return d.ds10.SectorStartEpoch
 }
 
+func (d dealStateV10) SectorNumber() abi.SectorNumber {
+
+	return 0
+
+}
+
 func (d dealStateV10) LastUpdatedEpoch() abi.ChainEpoch {
 	return d.ds10.LastUpdatedEpoch
 }

--- a/chain/actors/builtin/market/v11.go
+++ b/chain/actors/builtin/market/v11.go
@@ -135,6 +135,12 @@ func (d dealStateV11) SectorStartEpoch() abi.ChainEpoch {
 	return d.ds11.SectorStartEpoch
 }
 
+func (d dealStateV11) SectorNumber() abi.SectorNumber {
+
+	return 0
+
+}
+
 func (d dealStateV11) LastUpdatedEpoch() abi.ChainEpoch {
 	return d.ds11.LastUpdatedEpoch
 }

--- a/chain/actors/builtin/market/v11.go
+++ b/chain/actors/builtin/market/v11.go
@@ -294,7 +294,7 @@ func (s *state11) GetProviderSectors() (map[abi.SectorID][]abi.DealID, error) {
 
 }
 
-func (s *state11) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool) (map[abi.DealID]abi.SectorID, error) {
+func (s *state11) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool, sectorIDMap map[abi.SectorNumber]bool) (map[abi.DealID]abi.SectorID, error) {
 
 	return nil, nil
 

--- a/chain/actors/builtin/market/v12.go
+++ b/chain/actors/builtin/market/v12.go
@@ -294,7 +294,7 @@ func (s *state12) GetProviderSectors() (map[abi.SectorID][]abi.DealID, error) {
 
 }
 
-func (s *state12) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool) (map[abi.DealID]abi.SectorID, error) {
+func (s *state12) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool, sectorIDMap map[abi.SectorNumber]bool) (map[abi.DealID]abi.SectorID, error) {
 
 	return nil, nil
 

--- a/chain/actors/builtin/market/v12.go
+++ b/chain/actors/builtin/market/v12.go
@@ -135,6 +135,12 @@ func (d dealStateV12) SectorStartEpoch() abi.ChainEpoch {
 	return d.ds12.SectorStartEpoch
 }
 
+func (d dealStateV12) SectorNumber() abi.SectorNumber {
+
+	return 0
+
+}
+
 func (d dealStateV12) LastUpdatedEpoch() abi.ChainEpoch {
 	return d.ds12.LastUpdatedEpoch
 }

--- a/chain/actors/builtin/market/v13.go
+++ b/chain/actors/builtin/market/v13.go
@@ -326,7 +326,7 @@ func (s *state13) GetProviderSectors() (map[abi.SectorID][]abi.DealID, error) {
 
 }
 
-func (s *state13) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool) (map[abi.DealID]abi.SectorID, error) {
+func (s *state13) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool, sectorIDMap map[abi.SectorNumber]bool) (map[abi.DealID]abi.SectorID, error) {
 
 	sectorDeals, err := adt13.AsMap(s.store, s.State.ProviderSectors, market13.ProviderSectorsHamtBitwidth)
 	if err != nil {
@@ -350,6 +350,10 @@ func (s *state13) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool) (map
 			sectorNumber, err := abi.ParseUIntKey(sectorID)
 			if err != nil {
 				return err
+			}
+
+			if _, found := sectorIDMap[abi.SectorNumber(sectorNumber)]; !found {
+				return nil
 			}
 
 			dealIDsCopy := make([]abi.DealID, len(dealIDs))

--- a/chain/actors/builtin/market/v13.go
+++ b/chain/actors/builtin/market/v13.go
@@ -135,6 +135,12 @@ func (d dealStateV13) SectorStartEpoch() abi.ChainEpoch {
 	return d.ds13.SectorStartEpoch
 }
 
+func (d dealStateV13) SectorNumber() abi.SectorNumber {
+
+	return d.ds13.SectorNumber
+
+}
+
 func (d dealStateV13) LastUpdatedEpoch() abi.ChainEpoch {
 	return d.ds13.LastUpdatedEpoch
 }

--- a/chain/actors/builtin/market/v2.go
+++ b/chain/actors/builtin/market/v2.go
@@ -139,6 +139,12 @@ func (d dealStateV2) SectorStartEpoch() abi.ChainEpoch {
 	return d.ds2.SectorStartEpoch
 }
 
+func (d dealStateV2) SectorNumber() abi.SectorNumber {
+
+	return 0
+
+}
+
 func (d dealStateV2) LastUpdatedEpoch() abi.ChainEpoch {
 	return d.ds2.LastUpdatedEpoch
 }

--- a/chain/actors/builtin/market/v2.go
+++ b/chain/actors/builtin/market/v2.go
@@ -282,7 +282,7 @@ func (s *state2) GetProviderSectors() (map[abi.SectorID][]abi.DealID, error) {
 
 }
 
-func (s *state2) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool) (map[abi.DealID]abi.SectorID, error) {
+func (s *state2) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool, sectorIDMap map[abi.SectorNumber]bool) (map[abi.DealID]abi.SectorID, error) {
 
 	return nil, nil
 

--- a/chain/actors/builtin/market/v3.go
+++ b/chain/actors/builtin/market/v3.go
@@ -134,6 +134,12 @@ func (d dealStateV3) SectorStartEpoch() abi.ChainEpoch {
 	return d.ds3.SectorStartEpoch
 }
 
+func (d dealStateV3) SectorNumber() abi.SectorNumber {
+
+	return 0
+
+}
+
 func (d dealStateV3) LastUpdatedEpoch() abi.ChainEpoch {
 	return d.ds3.LastUpdatedEpoch
 }

--- a/chain/actors/builtin/market/v3.go
+++ b/chain/actors/builtin/market/v3.go
@@ -277,7 +277,7 @@ func (s *state3) GetProviderSectors() (map[abi.SectorID][]abi.DealID, error) {
 
 }
 
-func (s *state3) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool) (map[abi.DealID]abi.SectorID, error) {
+func (s *state3) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool, sectorIDMap map[abi.SectorNumber]bool) (map[abi.DealID]abi.SectorID, error) {
 
 	return nil, nil
 

--- a/chain/actors/builtin/market/v4.go
+++ b/chain/actors/builtin/market/v4.go
@@ -277,7 +277,7 @@ func (s *state4) GetProviderSectors() (map[abi.SectorID][]abi.DealID, error) {
 
 }
 
-func (s *state4) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool) (map[abi.DealID]abi.SectorID, error) {
+func (s *state4) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool, sectorIDMap map[abi.SectorNumber]bool) (map[abi.DealID]abi.SectorID, error) {
 
 	return nil, nil
 

--- a/chain/actors/builtin/market/v4.go
+++ b/chain/actors/builtin/market/v4.go
@@ -134,6 +134,12 @@ func (d dealStateV4) SectorStartEpoch() abi.ChainEpoch {
 	return d.ds4.SectorStartEpoch
 }
 
+func (d dealStateV4) SectorNumber() abi.SectorNumber {
+
+	return 0
+
+}
+
 func (d dealStateV4) LastUpdatedEpoch() abi.ChainEpoch {
 	return d.ds4.LastUpdatedEpoch
 }

--- a/chain/actors/builtin/market/v5.go
+++ b/chain/actors/builtin/market/v5.go
@@ -134,6 +134,12 @@ func (d dealStateV5) SectorStartEpoch() abi.ChainEpoch {
 	return d.ds5.SectorStartEpoch
 }
 
+func (d dealStateV5) SectorNumber() abi.SectorNumber {
+
+	return 0
+
+}
+
 func (d dealStateV5) LastUpdatedEpoch() abi.ChainEpoch {
 	return d.ds5.LastUpdatedEpoch
 }

--- a/chain/actors/builtin/market/v5.go
+++ b/chain/actors/builtin/market/v5.go
@@ -277,7 +277,7 @@ func (s *state5) GetProviderSectors() (map[abi.SectorID][]abi.DealID, error) {
 
 }
 
-func (s *state5) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool) (map[abi.DealID]abi.SectorID, error) {
+func (s *state5) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool, sectorIDMap map[abi.SectorNumber]bool) (map[abi.DealID]abi.SectorID, error) {
 
 	return nil, nil
 

--- a/chain/actors/builtin/market/v6.go
+++ b/chain/actors/builtin/market/v6.go
@@ -277,7 +277,7 @@ func (s *state6) GetProviderSectors() (map[abi.SectorID][]abi.DealID, error) {
 
 }
 
-func (s *state6) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool) (map[abi.DealID]abi.SectorID, error) {
+func (s *state6) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool, sectorIDMap map[abi.SectorNumber]bool) (map[abi.DealID]abi.SectorID, error) {
 
 	return nil, nil
 

--- a/chain/actors/builtin/market/v6.go
+++ b/chain/actors/builtin/market/v6.go
@@ -134,6 +134,12 @@ func (d dealStateV6) SectorStartEpoch() abi.ChainEpoch {
 	return d.ds6.SectorStartEpoch
 }
 
+func (d dealStateV6) SectorNumber() abi.SectorNumber {
+
+	return 0
+
+}
+
 func (d dealStateV6) LastUpdatedEpoch() abi.ChainEpoch {
 	return d.ds6.LastUpdatedEpoch
 }

--- a/chain/actors/builtin/market/v7.go
+++ b/chain/actors/builtin/market/v7.go
@@ -134,6 +134,12 @@ func (d dealStateV7) SectorStartEpoch() abi.ChainEpoch {
 	return d.ds7.SectorStartEpoch
 }
 
+func (d dealStateV7) SectorNumber() abi.SectorNumber {
+
+	return 0
+
+}
+
 func (d dealStateV7) LastUpdatedEpoch() abi.ChainEpoch {
 	return d.ds7.LastUpdatedEpoch
 }

--- a/chain/actors/builtin/market/v7.go
+++ b/chain/actors/builtin/market/v7.go
@@ -277,7 +277,7 @@ func (s *state7) GetProviderSectors() (map[abi.SectorID][]abi.DealID, error) {
 
 }
 
-func (s *state7) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool) (map[abi.DealID]abi.SectorID, error) {
+func (s *state7) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool, sectorIDMap map[abi.SectorNumber]bool) (map[abi.DealID]abi.SectorID, error) {
 
 	return nil, nil
 

--- a/chain/actors/builtin/market/v8.go
+++ b/chain/actors/builtin/market/v8.go
@@ -135,6 +135,12 @@ func (d dealStateV8) SectorStartEpoch() abi.ChainEpoch {
 	return d.ds8.SectorStartEpoch
 }
 
+func (d dealStateV8) SectorNumber() abi.SectorNumber {
+
+	return 0
+
+}
+
 func (d dealStateV8) LastUpdatedEpoch() abi.ChainEpoch {
 	return d.ds8.LastUpdatedEpoch
 }

--- a/chain/actors/builtin/market/v8.go
+++ b/chain/actors/builtin/market/v8.go
@@ -294,7 +294,7 @@ func (s *state8) GetProviderSectors() (map[abi.SectorID][]abi.DealID, error) {
 
 }
 
-func (s *state8) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool) (map[abi.DealID]abi.SectorID, error) {
+func (s *state8) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool, sectorIDMap map[abi.SectorNumber]bool) (map[abi.DealID]abi.SectorID, error) {
 
 	return nil, nil
 

--- a/chain/actors/builtin/market/v9.go
+++ b/chain/actors/builtin/market/v9.go
@@ -294,7 +294,7 @@ func (s *state9) GetProviderSectors() (map[abi.SectorID][]abi.DealID, error) {
 
 }
 
-func (s *state9) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool) (map[abi.DealID]abi.SectorID, error) {
+func (s *state9) GetProviderSectorsByDealID(dealIDMap map[abi.DealID]bool, sectorIDMap map[abi.SectorNumber]bool) (map[abi.DealID]abi.SectorID, error) {
 
 	return nil, nil
 

--- a/chain/actors/builtin/market/v9.go
+++ b/chain/actors/builtin/market/v9.go
@@ -135,6 +135,12 @@ func (d dealStateV9) SectorStartEpoch() abi.ChainEpoch {
 	return d.ds9.SectorStartEpoch
 }
 
+func (d dealStateV9) SectorNumber() abi.SectorNumber {
+
+	return 0
+
+}
+
 func (d dealStateV9) LastUpdatedEpoch() abi.ChainEpoch {
 	return d.ds9.LastUpdatedEpoch
 }

--- a/lens/util/builtinactor.go
+++ b/lens/util/builtinactor.go
@@ -3,13 +3,14 @@ package util
 import (
 	"strconv"
 
-	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/fxamacker/cbor/v2"
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/dagcbor"
 	"github.com/ipld/go-ipld-prime/node/basicnode"
 	"github.com/ipld/go-ipld-prime/node/bindnode"
+
+	"github.com/filecoin-project/lotus/chain/types"
 )
 
 type KVEvent struct {

--- a/tasks/actorstate/market/sector_deals_v2.go
+++ b/tasks/actorstate/market/sector_deals_v2.go
@@ -70,24 +70,29 @@ func (SectorDealStateExtractor) Extract(ctx context.Context, a actorstate.ActorI
 	}
 
 	dealIDs := make(map[abi.DealID]bool, 0)
+	sectorIDs := make(map[abi.SectorNumber]bool, 0)
 
 	out := make(miner.MinerSectorDealListV2, 0)
 	for _, add := range changes.Added {
 		out = append(out, &miner.MinerSectorDealV2{
-			Height: int64(ec.CurrTs.Height()),
-			DealID: uint64(add.ID),
+			Height:   int64(ec.CurrTs.Height()),
+			DealID:   uint64(add.ID),
+			SectorID: uint64(add.Deal.SectorNumber()),
 		})
 		dealIDs[add.ID] = true
+		sectorIDs[add.Deal.SectorNumber()] = true
 	}
 	for _, mod := range changes.Modified {
 		out = append(out, &miner.MinerSectorDealV2{
-			Height: int64(ec.CurrTs.Height()),
-			DealID: uint64(mod.ID),
+			Height:   int64(ec.CurrTs.Height()),
+			DealID:   uint64(mod.ID),
+			SectorID: uint64(mod.To.SectorNumber()),
 		})
 		dealIDs[mod.ID] = true
+		sectorIDs[mod.To.SectorNumber()] = true
 	}
 
-	dealIDSectorMap, err := ec.CurrState.GetProviderSectorsByDealID(dealIDs)
+	dealIDSectorMap, err := ec.CurrState.GetProviderSectorsByDealID(dealIDs, sectorIDs)
 	if err != nil {
 		log.Errorf("Get the errors during getting provider sectors: %v", err)
 		return nil, nil


### PR DESCRIPTION
## Description
`ProviderSectors` is a nested HAMT structure, therefore it is hard to do the reversed search from dealID to ProviderID. It make the performance issue for `miner_sector_deal_v2`.

## Solution
Use the new field: `SectorNumber` in `DealState` and combine with `market.Proposals` to refine the performance of `miner_sector_deal_v2`.