### PR TITLE
feat: refactor builtin actor event

### DIFF
--- a/tasks/messages/builtinactorevent/task.go
+++ b/tasks/messages/builtinactorevent/task.go
@@ -72,7 +72,6 @@ func (t *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 	tsKey := executed.Key()
 	filter := &types.ActorEventFilter{
 		TipSetKey: &tsKey,
-		Fields:    fields,
 	}
 
 	report := &visormodel.ProcessingReport{

--- a/tasks/messages/builtinactorevent/task.go
+++ b/tasks/messages/builtinactorevent/task.go
@@ -79,6 +79,12 @@ func (t *Task) ProcessTipSets(ctx context.Context, current *types.TipSet, execut
 		StateRoot: current.ParentState().String(),
 	}
 
+	_, err := t.node.MessageExecutions(ctx, current, executed)
+	if err != nil {
+		report.ErrorsDetected = fmt.Errorf("getting messages executions for tipset: %w", err)
+		return nil, report, nil
+	}
+
 	events, err := t.node.GetActorEventsRaw(ctx, filter)
 	if err != nil {
 		log.Errorf("GetActorEventsRaw[pTs: %v, pHeight: %v, cTs: %v, cHeight: %v] err: %v", executed.Key().String(), executed.Height(), current.Key().String(), current.Height(), err)


### PR DESCRIPTION
## Description
The `builtin_actor_event` task took more than 30s in several epochs at 512G memory machine. Moreover, sometime we would miss the builtin_actor_events from api.

## Solution
1. Remove the filter for fields and more the filtering function in task code.
2. Add the message execution then it could trigger the function to collect builtin_actor_events.
