### PR TITLE
feat: add new column for locked_fil_v2 in chain_economics and address_type in data_cap_balances

### DIFF
--- a/model/actors/datacap/state.go
+++ b/model/actors/datacap/state.go
@@ -10,9 +10,11 @@ import (
 )
 
 const (
-	Added    = "ADDED"
-	Removed  = "REMOVED"
-	Modified = "MODIFIED"
+	Added          = "ADDED"
+	Removed        = "REMOVED"
+	Modified       = "MODIFIED"
+	Verifier       = "verifier"
+	VerifierClient = "verifier_client"
 )
 
 type DataCapBalance struct {
@@ -20,8 +22,9 @@ type DataCapBalance struct {
 	StateRoot string `pg:",pk,notnull"`
 	Address   string `pg:",pk,notnull"`
 
-	Event   string `pg:",notnull,type:data_cap_balance_event_type"`
-	DataCap string `pg:",notnull,type:numeric"`
+	Event       string `pg:",notnull,type:data_cap_balance_event_type"`
+	DataCap     string `pg:",notnull,type:numeric"`
+	AddressType string `pg:",notnull"`
 }
 
 func (d *DataCapBalance) Persist(ctx context.Context, s model.StorageBatch, _ model.Version) error {

--- a/model/chain/economics.go
+++ b/model/chain/economics.go
@@ -22,6 +22,7 @@ type ChainEconomics struct {
 	BurntFil            string   `pg:"type:numeric,notnull"`
 	LockedFil           string   `pg:"type:numeric,notnull"`
 	FilReserveDisbursed string   `pg:"type:numeric,notnull"`
+	LockedFilV2         string   `pg:"type:numeric,notnull"`
 }
 
 type ChainEconomicsV0 struct {

--- a/schemas/v1/39_add_locked_fil_v2_chaineconomics.go
+++ b/schemas/v1/39_add_locked_fil_v2_chaineconomics.go
@@ -5,6 +5,7 @@ func init() {
 		39,
 		`
 		ALTER TABLE {{ .SchemaName | default "public"}}.chain_economics ADD COLUMN IF NOT EXISTS locked_fil_v2 numeric DEFAULT 0;
+		ALTER TABLE {{ .SchemaName | default "public"}}.data_cap_balances ADD COLUMN IF NOT EXISTS address_type text DEFAULT '';
 `,
 	)
 }

--- a/schemas/v1/39_add_locked_fil_v2_chaineconomics.go
+++ b/schemas/v1/39_add_locked_fil_v2_chaineconomics.go
@@ -1,0 +1,10 @@
+package v1
+
+func init() {
+	patches.Register(
+		39,
+		`
+		ALTER TABLE {{ .SchemaName | default "public"}}.chain_economics ADD COLUMN IF NOT EXISTS locked_fil_v2 numeric DEFAULT 0;
+`,
+	)
+}

--- a/tasks/actorstate/datacap/balance.go
+++ b/tasks/actorstate/datacap/balance.go
@@ -109,13 +109,13 @@ func (extractor BalanceExtractor) Extract(ctx context.Context, a actorstate.Acto
 	}
 	preVerifregState, _ := verifreg.Load(node.Store(), preVerifregActor)
 
-	veriferChanges, err := verifreg.DiffVerifiers(ctx, node.Store(), preVerifregState, currentVerifregState)
+	verifierChanges, err := verifreg.DiffVerifiers(ctx, node.Store(), preVerifregState, currentVerifregState)
 	if err != nil {
 		return nil, fmt.Errorf("diffing verified registry verifiers: %w", err)
 	}
 
 	// a new verifier was added
-	for _, change := range veriferChanges.Added {
+	for _, change := range verifierChanges.Added {
 		balances = append(balances, &datacapmodel.DataCapBalance{
 			Height:      int64(ec.CurrTs.Height()),
 			StateRoot:   ec.CurrTs.ParentState().String(),
@@ -126,7 +126,7 @@ func (extractor BalanceExtractor) Extract(ctx context.Context, a actorstate.Acto
 		})
 	}
 	// a verifier was removed
-	for _, change := range changes.Removed {
+	for _, change := range verifierChanges.Removed {
 		balances = append(balances, &datacapmodel.DataCapBalance{
 			Height:      int64(ec.CurrTs.Height()),
 			StateRoot:   ec.CurrTs.ParentState().String(),
@@ -137,7 +137,7 @@ func (extractor BalanceExtractor) Extract(ctx context.Context, a actorstate.Acto
 		})
 	}
 	// an existing verifier's DataCap changed
-	for _, change := range changes.Modified {
+	for _, change := range verifierChanges.Modified {
 		balances = append(balances, &datacapmodel.DataCapBalance{
 			Height:      int64(ec.CurrTs.Height()),
 			StateRoot:   ec.CurrTs.ParentState().String(),

--- a/tasks/actorstate/datacap/balance.go
+++ b/tasks/actorstate/datacap/balance.go
@@ -10,25 +10,44 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/lily/chain/actors/adt"
 	"github.com/filecoin-project/lily/chain/actors/builtin/datacap"
+	"github.com/filecoin-project/lily/chain/actors/builtin/verifreg"
 	"github.com/filecoin-project/lily/model"
 	datacapmodel "github.com/filecoin-project/lily/model/actors/datacap"
 	"github.com/filecoin-project/lily/tasks/actorstate"
 
 	"github.com/filecoin-project/lotus/chain/types"
+	"github.com/filecoin-project/specs-actors/actors/builtin"
 )
 
 var log = logging.Logger("lily/tasks/datacap")
 
 type BalanceExtractor struct{}
 
-func (BalanceExtractor) Extract(ctx context.Context, a actorstate.ActorInfo, node actorstate.ActorStateAPI) (model.Persistable, error) {
+func (BalanceExtractor) getAddressType(verifierMap adt.Map, address address.Address) string {
+	var dcap abi.StoragePower
+	ok, err := verifierMap.Get(abi.AddrKey(address), &dcap)
+	if ok && err == nil {
+		return datacapmodel.Verifier
+	}
+	return datacapmodel.VerifierClient
+}
+
+func (extractor BalanceExtractor) Extract(ctx context.Context, a actorstate.ActorInfo, node actorstate.ActorStateAPI) (model.Persistable, error) {
 	log.Debugw("extract", zap.String("extractor", "BalanceExtractor"), zap.Inline(a))
 	ctx, span := otel.Tracer("").Start(ctx, "BalancesExtractor.Extract")
 	defer span.End()
 	if span.IsRecording() {
 		span.SetAttributes(a.Attributes()...)
 	}
+
+	verifregActor, actorErr := node.Actor(ctx, builtin.VerifiedRegistryActorAddr, a.Current.Key())
+	if actorErr != nil {
+		log.Errorf("get error during getting VerifiedRegistry: %v", actorErr)
+	}
+	verifregState, _ := verifreg.Load(node.Store(), verifregActor)
+	verifierMap, _ := verifregState.VerifiersMap()
 
 	ec, err := NewBalanceExtractionContext(ctx, a, node)
 	if err != nil {
@@ -41,11 +60,12 @@ func (BalanceExtractor) Extract(ctx context.Context, a actorstate.ActorInfo, nod
 	if !ec.HasPreviousState() {
 		if err := ec.CurrState.ForEachClient(func(addr address.Address, dcap abi.StoragePower) error {
 			balances = append(balances, &datacapmodel.DataCapBalance{
-				Height:    int64(ec.CurrTs.Height()),
-				StateRoot: ec.CurrTs.ParentState().String(),
-				Address:   addr.String(),
-				Event:     datacapmodel.Added,
-				DataCap:   dcap.String(),
+				Height:      int64(ec.CurrTs.Height()),
+				StateRoot:   ec.CurrTs.ParentState().String(),
+				Address:     addr.String(),
+				Event:       datacapmodel.Added,
+				DataCap:     dcap.String(),
+				AddressType: extractor.getAddressType(verifierMap, addr),
 			})
 			return nil
 		}); err != nil {
@@ -61,31 +81,35 @@ func (BalanceExtractor) Extract(ctx context.Context, a actorstate.ActorInfo, nod
 
 	for _, change := range changes.Added {
 		balances = append(balances, &datacapmodel.DataCapBalance{
-			Height:    int64(ec.CurrTs.Height()),
-			StateRoot: ec.CurrTs.ParentState().String(),
-			Address:   change.Address.String(),
-			Event:     datacapmodel.Added,
-			DataCap:   change.DataCap.String(),
+			Height:      int64(ec.CurrTs.Height()),
+			StateRoot:   ec.CurrTs.ParentState().String(),
+			Address:     change.Address.String(),
+			Event:       datacapmodel.Added,
+			DataCap:     change.DataCap.String(),
+			AddressType: extractor.getAddressType(verifierMap, change.Address),
 		})
+
 	}
 
 	for _, change := range changes.Removed {
 		balances = append(balances, &datacapmodel.DataCapBalance{
-			Height:    int64(ec.CurrTs.Height()),
-			StateRoot: ec.CurrTs.ParentState().String(),
-			Address:   change.Address.String(),
-			Event:     datacapmodel.Removed,
-			DataCap:   change.DataCap.String(),
+			Height:      int64(ec.CurrTs.Height()),
+			StateRoot:   ec.CurrTs.ParentState().String(),
+			Address:     change.Address.String(),
+			Event:       datacapmodel.Removed,
+			DataCap:     change.DataCap.String(),
+			AddressType: extractor.getAddressType(verifierMap, change.Address),
 		})
 	}
 
 	for _, change := range changes.Modified {
 		balances = append(balances, &datacapmodel.DataCapBalance{
-			Height:    int64(ec.CurrTs.Height()),
-			StateRoot: ec.CurrTs.ParentState().String(),
-			Address:   change.After.Address.String(),
-			Event:     datacapmodel.Modified,
-			DataCap:   change.After.DataCap.String(),
+			Height:      int64(ec.CurrTs.Height()),
+			StateRoot:   ec.CurrTs.ParentState().String(),
+			Address:     change.After.Address.String(),
+			Event:       datacapmodel.Modified,
+			DataCap:     change.After.DataCap.String(),
+			AddressType: extractor.getAddressType(verifierMap, change.After.Address),
 		})
 	}
 	return balances, nil

--- a/tasks/chaineconomics/economics_test.go
+++ b/tasks/chaineconomics/economics_test.go
@@ -2,6 +2,7 @@ package chaineconomics
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,7 +34,7 @@ func (m *MockedChainEconomicsLens) Store() adt.Store {
 	return nil
 }
 func (m *MockedChainEconomicsLens) MinerLoad(store adt.Store, act *types.Actor) (miner.State, error) {
-	return nil, nil
+	return nil, fmt.Errorf("test error")
 }
 
 func TestEconomicsModelExtraction(t *testing.T) {

--- a/tasks/chaineconomics/economics_test.go
+++ b/tasks/chaineconomics/economics_test.go
@@ -7,7 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/lily/chain/actors/adt"
+	"github.com/filecoin-project/lily/chain/actors/builtin/miner"
 	"github.com/filecoin-project/lily/testutil"
 
 	"github.com/filecoin-project/lotus/api"
@@ -21,6 +24,16 @@ type MockedChainEconomicsLens struct {
 func (m *MockedChainEconomicsLens) CirculatingSupply(ctx context.Context, ts *types.TipSet) (api.CirculatingSupply, error) {
 	args := m.Called(ctx, ts)
 	return args.Get(0).(api.CirculatingSupply), args.Error(1)
+}
+
+func (m *MockedChainEconomicsLens) Actor(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*types.Actor, error) {
+	return nil, nil
+}
+func (m *MockedChainEconomicsLens) Store() adt.Store {
+	return nil
+}
+func (m *MockedChainEconomicsLens) MinerLoad(store adt.Store, act *types.Actor) (miner.State, error) {
+	return nil, nil
 }
 
 func TestEconomicsModelExtraction(t *testing.T) {

--- a/tasks/chaineconomics/economics_test.go
+++ b/tasks/chaineconomics/economics_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 )
 
+// nolint: revive
 type MockedChainEconomicsLens struct {
 	mock.Mock
 }
@@ -27,13 +28,13 @@ func (m *MockedChainEconomicsLens) CirculatingSupply(ctx context.Context, ts *ty
 	return args.Get(0).(api.CirculatingSupply), args.Error(1)
 }
 
-func (m *MockedChainEconomicsLens) Actor(ctx context.Context, addr address.Address, tsk types.TipSetKey) (*types.Actor, error) {
+func (m *MockedChainEconomicsLens) Actor(_ context.Context, _ address.Address, _ types.TipSetKey) (*types.Actor, error) {
 	return nil, nil
 }
 func (m *MockedChainEconomicsLens) Store() adt.Store {
 	return nil
 }
-func (m *MockedChainEconomicsLens) MinerLoad(store adt.Store, act *types.Actor) (miner.State, error) {
+func (m *MockedChainEconomicsLens) MinerLoad(_ adt.Store, _ *types.Actor) (miner.State, error) {
 	return nil, fmt.Errorf("test error")
 }
 


### PR DESCRIPTION
### **Migration**
Need to run the migration script

`lily migrate --db="postgres://{user}:{password}@{host}:{port}/lily?sslmode=disable" --name migration --schema {schema} --to 1.39`