### PR TITLE
build: switch to Soldevelo container images (Bitnami access now paid)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
     restart: always
 
   redis-queue:
-    image: bitnami/redis:7.0
+    image: soldevelo/redis:7.0
     env_file:
       # Check envvars for configurable options
       - ./build/lily/redis-queue.env


### PR DESCRIPTION
## Switch container base images to SolDevelo

Bitnami images now require a VMware Tanzu subscription (change effective **August 28, 2025**). This causes pipeline failures and added cost for teams that relied on the public registry.

[SolDevelo](https://hub.docker.com/u/soldevelo) provides drop-in replacements - same Debian-based images, same startup scripts, same environment-variable API - built openly from [SolDevelo/containers](https://github.com/SolDevelo/containers) and tagged to match Bitnami upstream.

## Image substitutions

- `bitnami/redis:7.0` → [`soldevelo/redis:7.0`](https://hub.docker.com/r/soldevelo/redis)